### PR TITLE
fix: eol을 lf로 제한

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -6,6 +6,6 @@
   "trailingComma": "all",
   "printWidth": 80,
   "arrowParens": "avoid",
-  "endOfLine": "auto",
+  "endOfLine": "lf",
   "plugins": ["prettier-plugin-tailwindcss"]
 }


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- #8

## ✅ 작업 내용

- prettier의 eol 옵션을 `lf`로 변경합니다.
  - prettier에서 작업할 때 기본 값으로 `lf`를 권장하고 있기 때문입니다!
- 이에 맞게 기존 파일들의 eol을 변경하여 업로드 합니다.
- 추가로 세팅할 내용
  - window만
    - `git config core.autocrlf true` -> git이 line ending을 처리하는 방식을 결정합니다. core.autocrlf true로 하시면 저장소에서 가져올 때 CRLF로 가져오고, 저장소로 보낼 때는 LF로 보냅니다.
  - mac, linux만
    - `git config --global core.autocrlf input` eol을 lf만 사용하도록 합니다.

## 📝 참고 자료

- [git eol 변경](https://www.lesstif.com/gitbook/git-crlf-20776404.html)

## ♾️ 기타

- 추가로 필요한 작업 내용
