### PR TITLE
fix: Text 스토리북 meta title 수정

### DIFF
--- a/src/stories/Text.stories.tsx
+++ b/src/stories/Text.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import Text from '~/components/common/Text';
 
 const meta = {
-  title: 'Components/Text',
+  title: 'Components/Common/Text',
   component: Text,
 } satisfies Meta<typeof Text>;
 


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- #13 

## ✅ 작업 내용

- Text.stories.tsx의 meta title 경로를 수정하였습니다.

## 📝 참고 자료


## ♾️ 기타

- 추가로 필요한 작업 내용
