### PR TITLE
feat: Textarea 컴포넌트 구현

### DIFF
--- a/src/components/common/Textarea/index.tsx
+++ b/src/components/common/Textarea/index.tsx
@@ -1,0 +1,50 @@
+import { ComponentProps, useRef } from 'react';
+
+import { cn } from '~/utils/cn';
+
+interface TextareaProps extends ComponentProps<'textarea'> {
+  size?: 'sm' | 'lg';
+  placeholder?: string;
+  required?: boolean;
+  disabled?: boolean;
+}
+
+const Textarea = ({
+  size = 'sm',
+  placeholder = '',
+  required = false,
+  disabled = false,
+  className,
+  ...props
+}: TextareaProps) => {
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+
+  const resizeTextarea = () => {
+    const textarea = textareaRef.current;
+
+    if (!textarea) return;
+
+    if (size === 'sm' && Number(textarea.scrollHeight) > 145) return;
+
+    textarea.style.height = 'auto';
+    textarea.style.height = `${textarea.scrollHeight}px`;
+  };
+
+  return (
+    <textarea
+      placeholder={placeholder}
+      required={required}
+      disabled={disabled}
+      ref={textareaRef}
+      onInput={resizeTextarea}
+      rows={1}
+      className={cn(
+        'box-border w-full resize-none px-3 py-1.5 outline-none',
+        className,
+      )}
+      {...props}
+    />
+  );
+};
+
+export default Textarea;

--- a/src/stories/Textarea.stories.tsx
+++ b/src/stories/Textarea.stories.tsx
@@ -1,0 +1,45 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import Textarea from '~/components/common/Textarea';
+
+const meta: Meta<typeof Textarea> = {
+  title: 'Components/Common/Textarea',
+  component: Textarea,
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Textarea>;
+
+export const Default: Story = {
+  args: {
+    size: 'sm',
+    placeholder: 'Textarea 컴포넌트',
+    required: false,
+    disabled: false,
+  },
+  argTypes: {
+    size: {
+      control: 'radio',
+      options: ['sm', 'lg'],
+    },
+    placeholder: { control: 'text' },
+    required: { control: 'boolean' },
+    disabled: { control: 'boolean' },
+  },
+  render: args => {
+    return (
+      <>
+        <Textarea {...args} />
+        <Textarea placeholder="메시지 보내기" className="bg-gray-100" />
+        <Textarea placeholder="댓글을 등록하려면 로그인 해야합니다." disabled />
+        <Textarea placeholder="댓글을 입력하세요." className="bg-gray-100" />
+        <Textarea
+          size="lg"
+          placeholder="내용을 입력하세요"
+          className="bg-gray-100"
+        />
+      </>
+    );
+  },
+};


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- #9 

## ✅ 작업 내용
- `size`, `placeholder`, `required`, `disabled` props를 받습니다.
- `size`는 `sm`, `lg`로 구분되며 구분 기준은 다음과 같습니다.
  - `sm`: 댓글 입력, 채팅 메시지 입력과 같이 `height`가 작은 `textarea`로, 텍스트 길이에 따라 `height`가 늘어나지만 일정 길이 (약 6줄) 이상일 땐 더이상 늘어나지 않는다.
  - `lg`: 게시물 입력과 같이 `height`가 일정 길이까지만 늘어나지 않고 화면에서 보이는 만큼 늘어난다.
- storybook에서는 잘 보이게 하기 위해 배경색을 넣었습니다. 보통 배경색 없이 사용될 것으로 예상됩니다.

## 📝 참고 자료

## ♾️ 기타
- 따로 `variants` 등록할 부분이 없다고 생각해서 `cva`를 사용하지 않았는데 다른 의견이 있다면 말해주세요!
- 기본 스타일을 지정하다 보니 좀 많아진 것 같은데.. 이렇게 작성해도 괜찮은 걸까요?
  ![image](https://github.com/prgrms-fe-devcourse/FEDC5_Owhat_Byunghyun/assets/42732729/e2e6feb9-7081-4696-8113-20fc5fd0a2e2)
- `size="sm"`일 때 사용되는 최대 높이(`145`)를 상수화(예 - `const MAX_HEIGHT_VALUE = 145`)하는 것이 좋을까요? 의미를 파악하기 힘든 매직 넘버가 되는 것 같아 고민입니다!