### PR TITLE
Feat: input 컴포넌트

### DIFF
--- a/src/components/common/Input/Input.variants.ts
+++ b/src/components/common/Input/Input.variants.ts
@@ -1,0 +1,32 @@
+import { cva } from 'class-variance-authority';
+
+export const InputVariants = cva(``, {
+  variants: {
+    borderColor: {
+      default: 'border border-gray-300',
+      white: 'border border-white',
+      primary: 'border border-primary',
+    },
+    outlineColor: {
+      default: 'focus:outline-none focus:border-primary',
+      lightGray: 'focus:outline-none focus:border-gray-300',
+      none: 'focus:outline-none focus:border-transparent',
+    },
+    isBorderNone: {
+      default: false,
+      true: 'rounded-none border-x-0 border-y-0 ',
+      false: 'border',
+    },
+    isBottomBorderOnly: {
+      default: false,
+      true: 'rounded-none border-x-0 border-t-0',
+      false: '',
+    },
+  },
+  defaultVariants: {
+    borderColor: 'default',
+    outlineColor: 'default',
+    isBorderNone: 'default',
+    isBottomBorderOnly: 'default',
+  },
+});

--- a/src/components/common/Input/Input.variants.ts
+++ b/src/components/common/Input/Input.variants.ts
@@ -14,7 +14,7 @@ export const InputVariants = cva(``, {
     },
     isBorderNone: {
       default: false,
-      true: 'rounded-none border-x-0 border-y-0 ',
+      true: 'border-transparent',
       false: 'border',
     },
     isBottomBorderOnly: {

--- a/src/components/common/Input/index.tsx
+++ b/src/components/common/Input/index.tsx
@@ -27,14 +27,14 @@ const Input = ({
       onChange={onChange}
       placeholder={placeholder}
       className={cn(
-        'rounded-[8px] px-2 py-1',
+        'rounded-[8px] px-2 py-1 text-black placeholder:text-sm',
         InputVariants({
           borderColor,
           outlineColor,
           isBorderNone,
           isBottomBorderOnly,
         }),
-        `${className} `,
+        `${className}`,
       )}
     />
   );

--- a/src/components/common/Input/index.tsx
+++ b/src/components/common/Input/index.tsx
@@ -21,9 +21,11 @@ const Input = ({
   isBorderNone,
   isBottomBorderOnly,
   inputType,
+  ...props
 }: InputProps) => {
   return (
     <input
+      {...props}
       id={id}
       type={inputType}
       onChange={onChange}

--- a/src/components/common/Input/index.tsx
+++ b/src/components/common/Input/index.tsx
@@ -1,0 +1,43 @@
+import { VariantProps } from 'class-variance-authority';
+import { ComponentProps } from 'react';
+
+import { cn } from '~/utils/cn';
+
+import { InputVariants } from './Input.variants';
+
+interface InputProps
+  extends VariantProps<typeof InputVariants>,
+    ComponentProps<'input'> {}
+
+const Input = ({
+  id,
+  placeholder,
+  className,
+  onChange,
+  borderColor,
+  outlineColor,
+  isBorderNone,
+  isBottomBorderOnly,
+  type,
+}: InputProps) => {
+  return (
+    <input
+      id={id}
+      type={type}
+      onChange={onChange}
+      placeholder={placeholder}
+      className={cn(
+        'rounded-[8px] px-2 py-1',
+        InputVariants({
+          borderColor,
+          outlineColor,
+          isBorderNone,
+          isBottomBorderOnly,
+        }),
+        `${className} `,
+      )}
+    />
+  );
+};
+
+export default Input;

--- a/src/components/common/Input/index.tsx
+++ b/src/components/common/Input/index.tsx
@@ -7,7 +7,9 @@ import { InputVariants } from './Input.variants';
 
 interface InputProps
   extends VariantProps<typeof InputVariants>,
-    ComponentProps<'input'> {}
+    ComponentProps<'input'> {
+  inputType: 'text' | 'password' | 'number' | 'email';
+}
 
 const Input = ({
   id,
@@ -18,12 +20,12 @@ const Input = ({
   outlineColor,
   isBorderNone,
   isBottomBorderOnly,
-  type,
+  inputType,
 }: InputProps) => {
   return (
     <input
       id={id}
-      type={type}
+      type={inputType}
       onChange={onChange}
       placeholder={placeholder}
       className={cn(

--- a/src/stories/Input.stories.tsx
+++ b/src/stories/Input.stories.tsx
@@ -22,7 +22,9 @@ export default meta;
 
 export const InputExample: StoryObj<typeof Input> = {
   args: {
-    onChange: () => {},
+    onChange: event => {
+      event.target.value;
+    },
     borderColor: 'default',
     outlineColor: 'default',
     placeholder: '내용을 입력해주세요.',

--- a/src/stories/Input.stories.tsx
+++ b/src/stories/Input.stories.tsx
@@ -1,0 +1,32 @@
+import { Meta, StoryObj } from '@storybook/react';
+
+import Input from '~/components/common/Input';
+
+const meta = {
+  title: 'Common/Components/Input',
+  component: Input,
+  argTypes: {
+    onChange: { action: 'onChangeFunc', control: 'function' },
+    placeholder: { control: 'text' },
+    isBorderNone: { control: 'boolean' },
+    isBottomBorderOnly: { control: 'boolean' },
+  },
+  parameters: {
+    actions: {
+      handles: ['onChangeFunc'],
+    },
+  },
+} satisfies Meta<typeof Input>;
+
+export default meta;
+
+export const InputExample: StoryObj<typeof Input> = {
+  args: {
+    onChange: () => {},
+    borderColor: 'default',
+    outlineColor: 'default',
+    placeholder: '내용을 입력해주세요.',
+    isBorderNone: false,
+  },
+  render: args => <Input {...args} />,
+};


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

close #1 

## ✅ 작업 내용

- input type을 email, password, text, number, hidden 중에 설정할 수 있습니다.
- input이 bottom-border-line만 있는 것 또는 기본 형태 둘 중 하나를 선택할 수 있습니다.
- border가 none인 형태를 선택할 수 있습니다.
- input:focus의 outline 유무와 색상을 설정할 수 있습니다.
- input의 placeholder 값을 설정할 수 있습니다.

## 📝 참고 자료

## ♾️ 기타

- 추가로 필요한 작업 내용
