### PR TITLE
feat: Group 컴포넌트 생성

### DIFF
--- a/.github/workflows/chromatic.yaml
+++ b/.github/workflows/chromatic.yaml
@@ -1,0 +1,44 @@
+name: 'Chromatic'
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  chromatic:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: cache dependencies
+        id: cache
+        uses: actions/cache@v3
+        with:
+          path: '**/node_modules'
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}-storybook
+
+      - name: Install dependencies
+        if: ${{ steps.cache.outputs.cache-hit }} != 'true'
+        run: npm ci
+
+      - name: Publish to Chromatic
+        uses: chromaui/action@latest
+        id: chromatic
+        with:
+          # ⚠️ Make sure to configure a `CHROMATIC_PROJECT_TOKEN` repository secret
+          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          onlyChanged: true
+          exitZeroOnChanges: true
+          autoAcceptChanges: true
+
+      - name: comment PR
+        uses: thollander/actions-comment-pull-request@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          message: '🚀storybook: ${{ steps.chromatic.outputs.storybookUrl }}'

--- a/.prettierrc
+++ b/.prettierrc
@@ -7,5 +7,6 @@
   "printWidth": 80,
   "arrowParens": "avoid",
   "endOfLine": "auto",
-  "plugins": ["prettier-plugin-tailwindcss"]
+  "plugins": ["prettier-plugin-tailwindcss"],
+  "tailwindFunctions": ["clsx", "cn", "twmerge", "cva"]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "@typescript-eslint/parser": "^6.16.0",
         "@vitejs/plugin-react": "^4.2.1",
         "autoprefixer": "^10.4.16",
+        "chromatic": "^10.2.0",
         "clsx": "^2.0.0",
         "eslint": "^8.56.0",
         "eslint-config-prettier": "^9.1.0",
@@ -9110,6 +9111,17 @@
       "dev": true,
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/chromatic": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/chromatic/-/chromatic-10.2.0.tgz",
+      "integrity": "sha512-UDVGWa2Fx9CLCpwnyfvFHGr0vGF0ooB1TugUdgOcjC9pJXiFa67i7oaXMyTfVRIFxlt/QkqOJwdqDqqlLFffCw==",
+      "dev": true,
+      "bin": {
+        "chroma": "dist/bin.js",
+        "chromatic": "dist/bin.js",
+        "chromatic-cli": "dist/bin.js"
       }
     },
     "node_modules/ci-info": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "preview": "vite preview",
     "prepare": "chmod ug+x .husky/* && husky install",
     "storybook": "storybook dev -p 6006",
-    "build-storybook": "storybook build"
+    "build-storybook": "storybook build",
+    "chromatic": "npx chromatic --project-token=chpt_d26f7e471397016"
   },
   "lint-staged": {
     "**/*.{js,jsx,ts,tsx}": [
@@ -43,6 +44,7 @@
     "@typescript-eslint/parser": "^6.16.0",
     "@vitejs/plugin-react": "^4.2.1",
     "autoprefixer": "^10.4.16",
+    "chromatic": "^10.2.0",
     "clsx": "^2.0.0",
     "eslint": "^8.56.0",
     "eslint-config-prettier": "^9.1.0",
@@ -64,5 +66,7 @@
     "tailwindcss": "^3.4.0",
     "typescript": "^5.2.2",
     "vite": "^5.0.8"
-  }
+  },
+  "readme": "ERROR: No README data found!",
+  "_id": "owhat@0.0.0"
 }

--- a/src/common/components/Group/Group.variants.ts
+++ b/src/common/components/Group/Group.variants.ts
@@ -1,0 +1,60 @@
+import { cva } from 'class-variance-authority';
+
+export const groupVariants = cva(``, {
+  variants: {
+    direction: {
+      row: 'flex-row',
+      columns: 'flex-col',
+    },
+    position: {
+      default: 'left',
+      left: 'justify-start',
+      center: 'justify-center',
+      right: 'justify-end',
+      apart: 'justify-between',
+    },
+    align: {
+      start: 'items-start',
+      center: 'items-center',
+      end: 'items-end',
+    },
+    inline: {
+      true: 'inline-flex',
+      false: 'flex',
+    },
+    noWrap: {
+      true: 'flex-nowrap',
+      false: 'flex-wrap',
+    },
+    grow: {
+      true: '[&>*]:grow-1 [&>*]:w-full',
+      false: '[&>*]:grow-0',
+    },
+  },
+  defaultVariants: {
+    direction: 'row',
+    position: 'default',
+    align: 'start',
+    inline: false,
+    noWrap: false,
+    grow: false,
+  },
+});
+
+export type TSpacing = 'sm' | 'md' | 'lg';
+
+type TSpacingMap = {
+  [key in TSpacing]: number;
+};
+
+const spacingMap: TSpacingMap = {
+  sm: 8,
+  md: 20,
+  lg: 32,
+};
+
+export const getSpacing = (spacing: TSpacing | number) => {
+  if (typeof spacing === 'number') return spacing;
+
+  return spacingMap[spacing];
+};

--- a/src/common/components/Group/Group.variants.ts
+++ b/src/common/components/Group/Group.variants.ts
@@ -3,11 +3,10 @@ import { cva } from 'class-variance-authority';
 export const groupVariants = cva(``, {
   variants: {
     direction: {
-      row: 'flex-row',
+      rows: 'flex-row',
       columns: 'flex-col',
     },
     position: {
-      default: 'left',
       left: 'justify-start',
       center: 'justify-center',
       right: 'justify-end',
@@ -27,13 +26,13 @@ export const groupVariants = cva(``, {
       false: 'flex-wrap',
     },
     grow: {
-      true: '[&>*]:grow-1 [&>*]:w-full',
+      true: '[&>*]:grow-1 flex-nowrap [&>*]:w-full',
       false: '[&>*]:grow-0',
     },
   },
   defaultVariants: {
-    direction: 'row',
-    position: 'default',
+    direction: 'rows',
+    position: 'left',
     align: 'start',
     inline: false,
     noWrap: false,

--- a/src/common/components/Group/index.tsx
+++ b/src/common/components/Group/index.tsx
@@ -1,0 +1,49 @@
+import { VariantProps } from 'class-variance-authority';
+import { ComponentProps } from 'react';
+
+import { cn } from '~/utils/cn';
+
+import { getSpacing, groupVariants, TSpacing } from './Group.variants';
+
+export interface GroupProps
+  extends ComponentProps<'div'>,
+    VariantProps<typeof groupVariants> {
+  spacing: TSpacing | number;
+}
+
+const Group = ({
+  direction = 'row',
+  position = 'left',
+  align = 'start',
+  inline = false,
+  grow = false,
+  spacing = 'md',
+  noWrap,
+  className,
+  children,
+  ...props
+}: GroupProps) => {
+  const groupSpacing = getSpacing(spacing);
+
+  return (
+    <div
+      className={cn(
+        className,
+        groupVariants({
+          direction,
+          position,
+          align,
+          inline,
+          noWrap,
+          grow: grow && !inline,
+        }),
+      )}
+      style={{ gap: groupSpacing }}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+};
+
+export default Group;

--- a/src/stories/Group.stories.tsx
+++ b/src/stories/Group.stories.tsx
@@ -1,0 +1,74 @@
+import { Meta, StoryObj } from '@storybook/react';
+
+import Group from '~/common/components/Group';
+
+const meta: Meta<typeof Group> = {
+  title: 'Common/Components/Group',
+  component: Group,
+  argTypes: {
+    direction: {
+      control: 'radio',
+      options: ['row', 'columns'],
+    },
+    position: {
+      control: 'radio',
+      options: ['left', 'right', 'center', 'apart'],
+    },
+    align: {
+      control: 'radio',
+      options: ['start', 'center', 'end'],
+    },
+    inline: {
+      control: 'boolean',
+    },
+    grow: {
+      control: 'boolean',
+    },
+    spacing: {
+      control: 'radio',
+      options: ['sm', 'md', 'lg'],
+    },
+    noWrap: {
+      control: 'boolean',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Group>;
+
+export const Default: Story = {
+  render: args => {
+    return (
+      <Group {...args}>
+        <div className="h-28 w-32 bg-blue-500"></div>
+        <div className="h-48 w-28 bg-slate-700"></div>
+        <div className="h-40 w-40 bg-amber-500"></div>
+        <div className="h-28 w-36 bg-emerald-600"></div>
+      </Group>
+    );
+  },
+};
+
+export const Spacing: Story = {
+  argTypes: {
+    spacing: {
+      control: 'range',
+      min: 1,
+      max: 30,
+    },
+  },
+  args: {
+    spacing: 10,
+  },
+  render: args => {
+    return (
+      <Group {...args}>
+        <div className="h-28 w-32 bg-blue-500"></div>
+        <div className="h-48 w-28 bg-slate-700"></div>
+        <div className="h-40 w-40 bg-amber-500"></div>
+        <div className="h-28 w-36 bg-emerald-600"></div>
+      </Group>
+    );
+  },
+};

--- a/src/stories/Group.stories.tsx
+++ b/src/stories/Group.stories.tsx
@@ -32,6 +32,15 @@ const meta: Meta<typeof Group> = {
       control: 'boolean',
     },
   },
+  args: {
+    direction: 'row',
+    position: 'left',
+    align: 'start',
+    inline: false,
+    grow: false,
+    spacing: 'md',
+    noWrap: false,
+  },
 };
 
 export default meta;


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- close #17

## ✅ 작업 내용

- 스토리북 배포 ci/cd 구축
  - chromatic을 통해 스토리북을 배포합니다.
  - chromatic을 이용한 이유는 스토리북 관리자가 만든 배포 서비스이므로 연동하기가 쉽고, 컴포넌트 미리보기, 빌드 과정 등을 최적화 하여 제공하기 때문입니다.
  - 빌드가 완료 되면 PR 메시지로 스토리북 배포 url을 자동으로 작성해줍니다.
- Group 컴포넌트 작성
  - Group 컴포넌트는 다음과 같은 일을 할 수 있습니다.
  - 가로, 세로 방향 선택
  - 가로 정렬, 세로 정렬 선택
  - 부모 요소 최대 너비에 맞게 모든 자식 요소의 크기를 strech
  - 자식 요소들 간의 간격 조정
  - wrapping 가능 여부 설정

## 📝 참고 자료

## ♾️ 기타
