### PR TITLE
feat: Button 컴포넌트 구현

### DIFF
--- a/src/common/components/Button/Button.variants.ts
+++ b/src/common/components/Button/Button.variants.ts
@@ -8,10 +8,10 @@ export const buttonVarients = cva(
         primary:
           'rounded-lg bg-primary text-white hover:bg-[#cc6600] focus:outline-none',
         secondary:
-          'rounded-md bg-white text-primary hover:bg-[#cc6600] focus:outline-none',
+          'rounded-md bg-white text-primary hover:bg-primary hover:text-white focus:outline-none',
         outline:
-          'rounded-md border border-primary text-primary hover:bg-[#cc6600] focus:outline-none',
-        ghost: 'hover:bg-[#cc6600]focus:outline-none rounded-md text-primary',
+          'rounded-md border border-primary text-primary hover:bg-primary hover:text-white focus:outline-none',
+        ghost: 'hover:fill-gray-600 focus:outline-none rounded-md text-primary',
       },
     },
     defaultVariants: {

--- a/src/common/components/Button/Button.variants.ts
+++ b/src/common/components/Button/Button.variants.ts
@@ -1,0 +1,21 @@
+import { cva } from 'class-variance-authority';
+
+export const buttonVarients = cva(
+  `relative px-4 py-2 text-md font-semibold transition-opacity`,
+  {
+    variants: {
+      styleType: {
+        primary:
+          'rounded-lg bg-primary text-white hover:opacity-60 focus:outline-none',
+        secondary:
+          'rounded-md bg-white text-primary hover:opacity-60 focus:outline-none',
+        outline:
+          'rounded-md border border-primary text-primary hover:opacity-60 focus:outline-none',
+        ghost: 'rounded-md text-primary hover:opacity-60 focus:outline-none',
+      },
+    },
+    defaultVariants: {
+      styleType: 'primary',
+    },
+  },
+);

--- a/src/common/components/Button/Button.variants.ts
+++ b/src/common/components/Button/Button.variants.ts
@@ -1,17 +1,17 @@
 import { cva } from 'class-variance-authority';
 
 export const buttonVarients = cva(
-  `relative px-4 py-2 text-md font-semibold transition-opacity`,
+  `text-md relative px-4 py-2 font-semibold transition-colors`,
   {
     variants: {
       styleType: {
         primary:
-          'rounded-lg bg-primary text-white hover:opacity-60 focus:outline-none',
+          'rounded-lg bg-primary text-white hover:bg-[#cc6600] focus:outline-none',
         secondary:
-          'rounded-md bg-white text-primary hover:opacity-60 focus:outline-none',
+          'rounded-md bg-white text-primary hover:bg-[#cc6600] focus:outline-none',
         outline:
-          'rounded-md border border-primary text-primary hover:opacity-60 focus:outline-none',
-        ghost: 'rounded-md text-primary hover:opacity-60 focus:outline-none',
+          'rounded-md border border-primary text-primary hover:bg-[#cc6600] focus:outline-none',
+        ghost: 'hover:bg-[#cc6600]focus:outline-none rounded-md text-primary',
       },
     },
     defaultVariants: {

--- a/src/common/components/Button/index.tsx
+++ b/src/common/components/Button/index.tsx
@@ -1,0 +1,51 @@
+import { ComponentProps } from 'react';
+
+import { cn } from '~/utils/cn';
+
+import Loading from '../Loading';
+
+export interface ButtonProps extends ComponentProps<'button'> {
+  children: React.ReactNode;
+  loading?: boolean;
+  fullwidth?: boolean;
+  type?: 'submit' | 'button' | 'reset';
+  disabled?: boolean;
+  border?: boolean;
+}
+
+const ButtonStyle =
+  'rounded-md p-1 px-3 hover:opacity-50 transition-opacity relative ';
+
+const Button = ({
+  children,
+  loading = false,
+  fullwidth,
+  type,
+  className,
+  border = true,
+  disabled,
+}: ButtonProps) => {
+  return (
+    <button
+      className={cn(
+        ButtonStyle,
+        { 'border-2 border-primary': border },
+        className,
+        `${fullwidth ? 'w-full' : ''}`,
+      )}
+      type={type}
+      disabled={disabled || loading}
+    >
+      {loading && (
+        <div className="absolute inset-0 flex items-center justify-center">
+          <Loading />
+        </div>
+      )}
+      <span className={`${loading ? 'invisible' : 'flex'} justify-center `}>
+        {children}
+      </span>
+    </button>
+  );
+};
+
+export default Button;

--- a/src/common/components/Button/index.tsx
+++ b/src/common/components/Button/index.tsx
@@ -1,37 +1,39 @@
+import { VariantProps } from 'class-variance-authority';
 import { ComponentProps } from 'react';
 
 import { cn } from '~/utils/cn';
 
 import Loading from '../Loading';
+import { buttonVarients } from './Button.variants';
 
-export interface ButtonProps extends ComponentProps<'button'> {
+export interface ButtonProps
+  extends VariantProps<typeof buttonVarients>,
+    ComponentProps<'button'> {
   children: React.ReactNode;
   loading?: boolean;
   fullwidth?: boolean;
   disabled?: boolean;
-  border?: boolean;
 }
-
-const ButtonStyle =
-  'rounded-md p-1 px-3 hover:opacity-50 transition-opacity relative ';
 
 const Button = ({
   children,
   loading = false,
   fullwidth,
   className,
-  border = true,
   disabled,
+  styleType,
+  ...props
 }: ButtonProps) => {
   return (
     <button
-      className={cn(
-        ButtonStyle,
-        { 'border-2 border-primary': border },
-        className,
-        `${fullwidth ? 'w-full' : ''}`,
-      )}
       disabled={disabled || loading}
+      className={cn(
+        buttonVarients({ styleType }),
+        className,
+        fullwidth ? 'w-full' : '',
+        disabled ? 'border-gray-300 bg-gray-300 text-white' : '',
+      )}
+      {...props}
     >
       {loading && (
         <div className="absolute inset-0 flex items-center justify-center">

--- a/src/common/components/Button/index.tsx
+++ b/src/common/components/Button/index.tsx
@@ -8,7 +8,6 @@ export interface ButtonProps extends ComponentProps<'button'> {
   children: React.ReactNode;
   loading?: boolean;
   fullwidth?: boolean;
-  type?: 'submit' | 'button' | 'reset';
   disabled?: boolean;
   border?: boolean;
 }
@@ -20,7 +19,6 @@ const Button = ({
   children,
   loading = false,
   fullwidth,
-  type,
   className,
   border = true,
   disabled,
@@ -33,7 +31,6 @@ const Button = ({
         className,
         `${fullwidth ? 'w-full' : ''}`,
       )}
-      type={type}
       disabled={disabled || loading}
     >
       {loading && (

--- a/src/common/components/Button/index.tsx
+++ b/src/common/components/Button/index.tsx
@@ -1,11 +1,12 @@
 import { VariantProps } from 'class-variance-authority';
 import { ComponentProps } from 'react';
 
+import Loading from '~/common/components/Loading';
 import { cn } from '~/utils/cn';
 
-import Loading from '../Loading';
 import { buttonVarients } from './Button.variants';
 
+//TODO: invisible 사용고려 - loading을 감싸는 rounded가 통일 되지않아 튀어나오는 버그 -> main 머지 후 해결 가능
 export interface ButtonProps
   extends VariantProps<typeof buttonVarients>,
     ComponentProps<'button'> {
@@ -30,7 +31,7 @@ const Button = ({
       className={cn(
         buttonVarients({ styleType }),
         className,
-        fullwidth ? 'w-full' : '',
+        fullwidth && 'w-full',
         disabled ? 'border-gray-300 bg-gray-300 text-white' : '',
       )}
       {...props}

--- a/src/common/components/Button/index.tsx
+++ b/src/common/components/Button/index.tsx
@@ -41,7 +41,9 @@ const Button = ({
           <Loading />
         </div>
       )}
-      <span className={`${loading ? 'invisible' : 'flex'} justify-center `}>
+      <span
+        className={`${loading ? 'invisible' : 'inline-block'} align-baseline`}
+      >
         {children}
       </span>
     </button>

--- a/src/stories/Button.stories.tsx
+++ b/src/stories/Button.stories.tsx
@@ -1,0 +1,55 @@
+import { Meta, StoryObj } from '@storybook/react';
+
+import Button from '~/common/components/Button';
+import Icon from '~/common/components/Icon';
+
+export default {
+  title: 'Common/Components/Button',
+  component: Button,
+  argTypes: {
+    type: {
+      options: ['button', 'submit'],
+      control: 'options',
+    },
+    fullwidth: {
+      control: 'boolean',
+    },
+    loading: {
+      control: 'boolean',
+    },
+    disabled: {
+      control: 'boolean',
+    },
+    border: {
+      control: 'boolean',
+    },
+  },
+  args: {},
+} satisfies Meta<typeof Button>;
+
+type Story = StoryObj<typeof Button>;
+
+export const Default: Story = {
+  render: function Render(args) {
+    return (
+      <>
+        <div>
+          <Button {...args} className="bg-primary">
+            button
+          </Button>
+        </div>
+        <div>
+          <Button {...args} className="border-none text-primary">
+            완료
+          </Button>
+        </div>
+
+        <div>
+          <Button {...args} className="border-gray">
+            <Icon id="search"></Icon>
+          </Button>
+        </div>
+      </>
+    );
+  },
+};

--- a/src/stories/Button.stories.tsx
+++ b/src/stories/Button.stories.tsx
@@ -7,9 +7,9 @@ export default {
   title: 'Common/Components/Button',
   component: Button,
   argTypes: {
-    type: {
-      options: ['button', 'submit'],
-      control: 'options',
+    styleType: {
+      options: ['primary', 'secondary', 'outline', 'ghost'],
+      control: 'inline-radio',
     },
     fullwidth: {
       control: 'boolean',
@@ -20,11 +20,12 @@ export default {
     disabled: {
       control: 'boolean',
     },
-    border: {
-      control: 'boolean',
-    },
   },
-  args: {},
+  args: {
+    fullwidth: false,
+    loading: false,
+    disabled: false,
+  },
 } satisfies Meta<typeof Button>;
 
 type Story = StoryObj<typeof Button>;
@@ -34,18 +35,23 @@ export const Default: Story = {
     return (
       <>
         <div>
-          <Button {...args} className="bg-primary">
+          <Button {...args} styleType={'primary'}>
             button
           </Button>
         </div>
         <div>
-          <Button {...args} className="border-none text-primary">
+          <Button {...args} styleType={'secondary'}>
             완료
           </Button>
         </div>
 
         <div>
-          <Button {...args} className="border-gray">
+          <Button {...args} styleType={'outline'}>
+            작성
+          </Button>
+        </div>
+        <div>
+          <Button {...args} styleType={'ghost'}>
             <Icon id="search"></Icon>
           </Button>
         </div>


### PR DESCRIPTION
## 🌍 이슈 번호 

- close #24 

## ✅ 작업 내용

- Loading 컴포넌트를 활용해 props로 loading값이 true가 되면 loading 컴포넌트 출력
- Lodiang 컴포넌트 출력시 버튼의 크기가 변하는 문제 해결
- hover시 opacity로 버튼효과 추가 - transition 적용
- fullwidth 기능구현
- Icon 컴포넌트를  Button요소에 출력 가능
- Props로 border 값을 설정해서 false면 border를 없애주는 기능 구현

## 📝 참고 자료

타입 명시가 없다면 기본적으로 'submit' 처리가 되며 'submit'은 새로고침을 하게 한다.

[버튼에 타입을 쓰는 이유 (button type="button")](https://nykim.work/96)


https://github.com/prgrms-fe-devcourse/FEDC5_Owhat_Byunghyun/assets/90139306/18540597-5788-47e8-8ace-72191389b89f



## ♾️ 기타

추후 현재 폰트 문제 해결
![image](https://github.com/prgrms-fe-devcourse/FEDC5_Owhat_Byunghyun/assets/90139306/abb285f3-52da-49e2-b6b8-8cdd0239aa3b)
