### PR TITLE
Fix: text component 수정

### DIFF
--- a/src/common/components/Text/Text.variants.ts
+++ b/src/common/components/Text/Text.variants.ts
@@ -3,7 +3,6 @@ import { cva } from 'class-variance-authority';
 export const textVariants = cva(`text-black`, {
   variants: {
     size: {
-      default: 'text-md',
       xs: `text-xs`,
       sm: `text-sm`,
       md: `text-md`,
@@ -13,12 +12,10 @@ export const textVariants = cva(`text-black`, {
       '3xl': `text-3xl`,
     },
     strong: {
-      default: 'font-normal',
       true: 'font-bold',
       false: 'font-normal',
     },
     decoration: {
-      default: 'no-underline',
       none: 'no-underline',
       underline: 'underline',
       overline: 'overline',
@@ -26,8 +23,8 @@ export const textVariants = cva(`text-black`, {
     },
   },
   defaultVariants: {
-    size: 'default',
-    strong: 'default',
-    decoration: 'default',
+    size: 'md',
+    strong: false,
+    decoration: 'none',
   },
 });

--- a/src/common/components/Text/Text.variants.ts
+++ b/src/common/components/Text/Text.variants.ts
@@ -21,10 +21,15 @@ export const textVariants = cva(`text-black`, {
       overline: 'overline',
       lineThrough: 'line-through',
     },
+    isLogo: {
+      true: 'font-logo',
+      false: 'font-sans',
+    },
   },
   defaultVariants: {
     size: 'md',
     strong: false,
     decoration: 'none',
+    isLogo: false,
   },
 });

--- a/src/common/components/Text/Text.variants.ts
+++ b/src/common/components/Text/Text.variants.ts
@@ -2,7 +2,7 @@ import { cva } from 'class-variance-authority';
 
 export const textVariants = cva(`text-black`, {
   variants: {
-    fontSize: {
+    size: {
       default: 'text-md',
       xs: `text-xs`,
       sm: `text-sm`,
@@ -26,7 +26,7 @@ export const textVariants = cva(`text-black`, {
     },
   },
   defaultVariants: {
-    fontSize: 'default',
+    size: 'default',
     strong: 'default',
     decoration: 'default',
   },

--- a/src/common/components/Text/Text.variants.ts
+++ b/src/common/components/Text/Text.variants.ts
@@ -1,6 +1,6 @@
 import { cva } from 'class-variance-authority';
 
-export const TextVariants = cva(``, {
+export const textVariants = cva(``, {
   variants: {
     fontColor: {
       default: 'text-black',

--- a/src/common/components/Text/Text.variants.ts
+++ b/src/common/components/Text/Text.variants.ts
@@ -1,18 +1,7 @@
 import { cva } from 'class-variance-authority';
 
-export const textVariants = cva(``, {
+export const textVariants = cva(`text-black`, {
   variants: {
-    fontColor: {
-      default: 'text-black',
-      primary: 'text-primary',
-      error: 'text-error',
-      success: 'text-success',
-      online: 'text-online',
-      black: 'text-black',
-      white: 'text-white',
-      lightGray: 'text-gray-300',
-      gray: 'text-gray-700',
-    },
     fontSize: {
       default: 'text-md',
       xs: `text-xs`,
@@ -37,7 +26,6 @@ export const textVariants = cva(``, {
     },
   },
   defaultVariants: {
-    fontColor: 'default',
     fontSize: 'default',
     strong: 'default',
     decoration: 'default',

--- a/src/common/components/Text/index.tsx
+++ b/src/common/components/Text/index.tsx
@@ -3,10 +3,10 @@ import { ComponentProps, ReactNode } from 'react';
 
 import { cn } from '~/utils/cn';
 
-import { TextVariants } from './Text.variants';
+import { textVariants } from './Text.variants';
 
 export interface TextProps
-  extends VariantProps<typeof TextVariants>,
+  extends VariantProps<typeof textVariants>,
     ComponentProps<'div'> {
   children: ReactNode;
 }
@@ -22,7 +22,7 @@ const Text = ({
   return (
     <div
       className={cn(
-        TextVariants({ fontColor, fontSize, strong, decoration }),
+        textVariants({ fontColor, fontSize, strong, decoration }),
         className,
       )}
     >

--- a/src/common/components/Text/index.tsx
+++ b/src/common/components/Text/index.tsx
@@ -1,16 +1,24 @@
 import { VariantProps } from 'class-variance-authority';
-import { ComponentProps, createElement, ReactNode } from 'react';
+import { ComponentProps, HTMLAttributes, ReactNode } from 'react';
 
 import { cn } from '~/utils/cn';
 
 import { textVariants } from './Text.variants';
 
-export interface TextProps
-  extends VariantProps<typeof textVariants>,
-    ComponentProps<'div'> {
-  children: ReactNode;
-  elementType?: 'div' | 'span' | 'p';
-}
+type ElementType = 'div' | 'span' | 'p';
+
+type ElementProps = {
+  div: HTMLAttributes<HTMLDivElement>;
+  span: HTMLAttributes<HTMLSpanElement>;
+  p: HTMLAttributes<HTMLParagraphElement>;
+};
+
+type TextProps<T extends ElementType> = ElementProps[T] &
+  VariantProps<typeof textVariants> & {
+    children: ReactNode;
+    elementType?: T;
+    className?: ComponentProps<typeof cn>;
+  };
 
 const Text = ({
   children,
@@ -21,17 +29,19 @@ const Text = ({
   elementType = 'div',
   isLogo = false,
   ...props
-}: TextProps) => {
-  return createElement(
-    elementType,
-    {
-      ...props,
-      className: cn(
+}: TextProps<ElementType>) => {
+  const Element = elementType;
+
+  return (
+    <Element
+      {...props}
+      className={cn(
         textVariants({ size, strong, decoration, isLogo }),
         className,
-      ),
-    },
-    children,
+      )}
+    >
+      {children}
+    </Element>
   );
 };
 

--- a/src/common/components/Text/index.tsx
+++ b/src/common/components/Text/index.tsx
@@ -11,9 +11,19 @@ export interface TextProps
   children: ReactNode;
 }
 
-const Text = ({ children, className, size, strong, decoration }: TextProps) => {
+const Text = ({
+  children,
+  className,
+  size,
+  strong,
+  decoration,
+  ...props
+}: TextProps) => {
   return (
-    <div className={cn(textVariants({ size, strong, decoration }), className)}>
+    <div
+      {...props}
+      className={cn(textVariants({ size, strong, decoration }), className)}
+    >
       {children}
     </div>
   );

--- a/src/common/components/Text/index.tsx
+++ b/src/common/components/Text/index.tsx
@@ -1,5 +1,5 @@
 import { VariantProps } from 'class-variance-authority';
-import { ComponentProps, ReactNode } from 'react';
+import { ComponentProps, createElement, ReactNode } from 'react';
 
 import { cn } from '~/utils/cn';
 
@@ -9,6 +9,7 @@ export interface TextProps
   extends VariantProps<typeof textVariants>,
     ComponentProps<'div'> {
   children: ReactNode;
+  elementType?: 'div' | 'span' | 'p';
 }
 
 const Text = ({
@@ -17,15 +18,16 @@ const Text = ({
   size,
   strong,
   decoration,
+  elementType = 'div',
   ...props
 }: TextProps) => {
-  return (
-    <div
-      {...props}
-      className={cn(textVariants({ size, strong, decoration }), className)}
-    >
-      {children}
-    </div>
+  return createElement(
+    elementType,
+    {
+      ...props,
+      className: cn(textVariants({ size, strong, decoration }), className),
+    },
+    children,
   );
 };
 

--- a/src/common/components/Text/index.tsx
+++ b/src/common/components/Text/index.tsx
@@ -11,17 +11,9 @@ export interface TextProps
   children: ReactNode;
 }
 
-const Text = ({
-  children,
-  className,
-  fontSize,
-  strong,
-  decoration,
-}: TextProps) => {
+const Text = ({ children, className, size, strong, decoration }: TextProps) => {
   return (
-    <div
-      className={cn(textVariants({ fontSize, strong, decoration }), className)}
-    >
+    <div className={cn(textVariants({ size, strong, decoration }), className)}>
       {children}
     </div>
   );

--- a/src/common/components/Text/index.tsx
+++ b/src/common/components/Text/index.tsx
@@ -15,17 +15,21 @@ export interface TextProps
 const Text = ({
   children,
   className,
-  size,
-  strong,
-  decoration,
+  size = 'md',
+  strong = false,
+  decoration = 'none',
   elementType = 'div',
+  isLogo = false,
   ...props
 }: TextProps) => {
   return createElement(
     elementType,
     {
       ...props,
-      className: cn(textVariants({ size, strong, decoration }), className),
+      className: cn(
+        textVariants({ size, strong, decoration, isLogo }),
+        className,
+      ),
     },
     children,
   );

--- a/src/common/components/Text/index.tsx
+++ b/src/common/components/Text/index.tsx
@@ -14,17 +14,13 @@ export interface TextProps
 const Text = ({
   children,
   className,
-  fontColor,
   fontSize,
   strong,
   decoration,
 }: TextProps) => {
   return (
     <div
-      className={cn(
-        textVariants({ fontColor, fontSize, strong, decoration }),
-        className,
-      )}
+      className={cn(textVariants({ fontSize, strong, decoration }), className)}
     >
       {children}
     </div>

--- a/src/stories/Text.stories.tsx
+++ b/src/stories/Text.stories.tsx
@@ -6,7 +6,7 @@ type fontSizeOption = 'xs' | 'sm' | 'md' | 'lg' | 'xl' | '2xl' | '3xl';
 
 type decorationOption = 'none' | 'underline' | 'overline' | 'lineThrough';
 
-const fontSizeOption: Array<fontSizeOption> = [
+const sizeOption: Array<fontSizeOption> = [
   'xs',
   'sm',
   'md',
@@ -27,8 +27,8 @@ const meta = {
   title: 'Common/Components/Text',
   component: Text,
   argTypes: {
-    fontSize: {
-      options: fontSizeOption,
+    size: {
+      options: sizeOption,
     },
     decoration: {
       options: decorationOption,
@@ -44,7 +44,7 @@ export default meta;
 export const PrimaryText: StoryObj<typeof Text> = {
   args: {
     children: 'Text',
-    fontSize: 'md',
+    size: 'md',
     decoration: 'none',
     strong: false,
   },

--- a/src/stories/Text.stories.tsx
+++ b/src/stories/Text.stories.tsx
@@ -2,37 +2,9 @@ import type { Meta, StoryObj } from '@storybook/react';
 
 import Text from '~/common/components/Text';
 
-const meta = {
-  title: 'Common/Components/Text',
-  component: Text,
-} satisfies Meta<typeof Text>;
-
-export default meta;
-
-type fontColorOption =
-  | 'primary'
-  | 'error'
-  | 'success'
-  | 'online'
-  | 'black'
-  | 'white'
-  | 'lightGray'
-  | 'gray';
-
 type fontSizeOption = 'xs' | 'sm' | 'md' | 'lg' | 'xl' | '2xl' | '3xl';
 
 type decorationOption = 'none' | 'underline' | 'overline' | 'lineThrough';
-
-const fontColorOption: Array<fontColorOption> = [
-  'primary',
-  'error',
-  'success',
-  'online',
-  'black',
-  'white',
-  'lightGray',
-  'gray',
-];
 
 const fontSizeOption: Array<fontSizeOption> = [
   'xs',
@@ -51,11 +23,10 @@ const decorationOption: Array<decorationOption> = [
   'lineThrough',
 ];
 
-export const PrimaryText: StoryObj<typeof Text> = {
+const meta = {
+  title: 'Common/Components/Text',
+  component: Text,
   argTypes: {
-    fontColor: {
-      options: fontColorOption,
-    },
     fontSize: {
       options: fontSizeOption,
     },
@@ -66,9 +37,13 @@ export const PrimaryText: StoryObj<typeof Text> = {
       control: 'boolean',
     },
   },
+} satisfies Meta<typeof Text>;
+
+export default meta;
+
+export const PrimaryText: StoryObj<typeof Text> = {
   args: {
     children: 'Text',
-    fontColor: 'primary',
     fontSize: 'md',
     decoration: 'none',
     strong: false,

--- a/src/stories/Text.stories.tsx
+++ b/src/stories/Text.stories.tsx
@@ -44,7 +44,7 @@ const meta = {
 
 export default meta;
 
-export const PrimaryText: StoryObj<typeof Text> = {
+export const Default: StoryObj<typeof Text> = {
   args: {
     children: 'Text',
     size: 'md',

--- a/src/stories/Text.stories.tsx
+++ b/src/stories/Text.stories.tsx
@@ -36,6 +36,9 @@ const meta = {
     strong: {
       control: 'boolean',
     },
+    isLogo: {
+      control: 'boolean',
+    },
   },
 } satisfies Meta<typeof Text>;
 
@@ -47,5 +50,6 @@ export const PrimaryText: StoryObj<typeof Text> = {
     size: 'md',
     decoration: 'none',
     strong: false,
+    isLogo: false,
   },
 };


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- close #28 

## ✅ 작업 내용

- 배경 색깔이나 border radius를 상위 컴포넌트에서 자유롭게 설정할 수 있도록 props를 변경합니다.
- stories의 color variants를 제거합니다.
- fontSize => size로 수정합니다.
- TextVariants => textVariants로 수정 (컴포넌트가 아니므로 케이스 변경)
- div, span, p 태그 중 변경할 수 있습니다.
- 폰트 패밀리를 변경할 수 있습니다. (isLogo: true 시 Logo 폰트로 변경)
- text story Obj 명칭을 다른 story Default obj와 이름을 통일시켰습니다.

## 📝 참고 자료


## ♾️ 기타

- 추가로 필요한 작업 내용
