### PR TITLE
feat: extrainfo 컴포넌트 구현

### DIFF
--- a/src/common/components/ExtraInfo/ExtraInfo.variants.ts
+++ b/src/common/components/ExtraInfo/ExtraInfo.variants.ts
@@ -1,0 +1,22 @@
+import { cva } from 'class-variance-authority';
+
+export const ExtraInfoVariants = cva(``, {
+  variants: {
+    gap: {
+      0: `gap-0`,
+      1: `gap-1`,
+      2: `gap-2`,
+      3: `gap-3`,
+      4: `gap-4`,
+      5: `gap-5`,
+      6: `gap-6`,
+      7: `gap-7`,
+      8: `gap-8`,
+      9: `gap-9`,
+      10: `gap-10`,
+    },
+  },
+  defaultVariants: {
+    gap: 1,
+  },
+});

--- a/src/common/components/ExtraInfo/ExtraInfo.variants.ts
+++ b/src/common/components/ExtraInfo/ExtraInfo.variants.ts
@@ -1,6 +1,6 @@
 import { cva } from 'class-variance-authority';
 
-export const extraInfoVariants = cva(``, {
+export const extraInfoVariants = cva(`flex text-sm font-thin text-gray-300`, {
   variants: {
     gap: {
       0: `gap-0`,

--- a/src/common/components/ExtraInfo/ExtraInfo.variants.ts
+++ b/src/common/components/ExtraInfo/ExtraInfo.variants.ts
@@ -1,6 +1,6 @@
 import { cva } from 'class-variance-authority';
 
-export const ExtraInfoVariants = cva(``, {
+export const extraInfoVariants = cva(``, {
   variants: {
     gap: {
       0: `gap-0`,

--- a/src/common/components/ExtraInfo/index.tsx
+++ b/src/common/components/ExtraInfo/index.tsx
@@ -1,6 +1,5 @@
 import { VariantProps } from 'class-variance-authority';
 import { Children, ComponentProps, ReactNode } from 'react';
-import { ClassNameValue } from 'tailwind-merge';
 
 import { cn } from '~/utils/cn';
 
@@ -8,24 +7,17 @@ import { extraInfoVariants } from './ExtraInfo.variants';
 
 export interface TextProps
   extends VariantProps<typeof extraInfoVariants>,
-    ComponentProps<'div'> {
+    ComponentProps<'ul'> {
   children: ReactNode | ReactNode[];
-  dividerClassName?: ClassNameValue;
 }
 
-const ExtraInfo = ({ className, gap = 1, children }: TextProps) => {
+const ExtraInfo = ({ className, gap = 1, children, ...props }: TextProps) => {
   const childComponents = Children.toArray(children);
 
   return (
-    <ul
-      className={cn(
-        'flex text-sm font-thin text-gray-300',
-        extraInfoVariants({ gap }),
-        className,
-      )}
-    >
+    <ul className={cn(extraInfoVariants({ gap }), className)} {...props}>
       {childComponents.map((child, index) => (
-        <li key={index} className={cn('flex', extraInfoVariants({ gap }))}>
+        <li key={index} className={cn(extraInfoVariants({ gap }))}>
           {child}
           {index < childComponents.length - 1 && <span>·</span>}
         </li>

--- a/src/common/components/ExtraInfo/index.tsx
+++ b/src/common/components/ExtraInfo/index.tsx
@@ -4,10 +4,10 @@ import { ClassNameValue } from 'tailwind-merge';
 
 import { cn } from '~/utils/cn';
 
-import { ExtraInfoVariants } from './ExtraInfo.variants';
+import { extraInfoVariants } from './ExtraInfo.variants';
 
 export interface TextProps
-  extends VariantProps<typeof ExtraInfoVariants>,
+  extends VariantProps<typeof extraInfoVariants>,
     ComponentProps<'div'> {
   children: ReactNode | ReactNode[];
   dividerClassName?: ClassNameValue;
@@ -20,12 +20,12 @@ const ExtraInfo = ({ className, gap = 1, children }: TextProps) => {
     <ul
       className={cn(
         'flex text-sm font-thin text-gray-300',
-        ExtraInfoVariants({ gap }),
+        extraInfoVariants({ gap }),
         className,
       )}
     >
       {childComponents.map((child, index) => (
-        <li key={index} className={cn('flex', ExtraInfoVariants({ gap }))}>
+        <li key={index} className={cn('flex', extraInfoVariants({ gap }))}>
           {child}
           {index < childComponents.length - 1 && <span>·</span>}
         </li>

--- a/src/common/components/ExtraInfo/index.tsx
+++ b/src/common/components/ExtraInfo/index.tsx
@@ -1,0 +1,26 @@
+import { Children, ComponentProps, ReactNode } from 'react';
+
+import { cn } from '~/utils/cn';
+
+export interface TextProps extends ComponentProps<'div'> {
+  children: ReactNode | ReactNode[];
+}
+
+const ExtraInfo = ({ className, children }: TextProps) => {
+  const childComponents = Children.toArray(children);
+
+  return (
+    <ul className={cn('flex text-sm font-thin text-gray-300', className)}>
+      {childComponents.map((child, index) => (
+        <li key={index}>
+          {child}
+          {index < childComponents.length - 1 && (
+            <span className="mx-1">·</span>
+          )}
+        </li>
+      ))}
+    </ul>
+  );
+};
+
+export default ExtraInfo;

--- a/src/common/components/ExtraInfo/index.tsx
+++ b/src/common/components/ExtraInfo/index.tsx
@@ -1,22 +1,33 @@
+import { VariantProps } from 'class-variance-authority';
 import { Children, ComponentProps, ReactNode } from 'react';
+import { ClassNameValue } from 'tailwind-merge';
 
 import { cn } from '~/utils/cn';
 
-export interface TextProps extends ComponentProps<'div'> {
+import { ExtraInfoVariants } from './ExtraInfo.variants';
+
+export interface TextProps
+  extends VariantProps<typeof ExtraInfoVariants>,
+    ComponentProps<'div'> {
   children: ReactNode | ReactNode[];
+  dividerClassName?: ClassNameValue;
 }
 
-const ExtraInfo = ({ className, children }: TextProps) => {
+const ExtraInfo = ({ className, gap = 1, children }: TextProps) => {
   const childComponents = Children.toArray(children);
 
   return (
-    <ul className={cn('flex text-sm font-thin text-gray-300', className)}>
+    <ul
+      className={cn(
+        'flex text-sm font-thin text-gray-300',
+        ExtraInfoVariants({ gap }),
+        className,
+      )}
+    >
       {childComponents.map((child, index) => (
-        <li key={index}>
+        <li key={index} className={cn('flex', ExtraInfoVariants({ gap }))}>
           {child}
-          {index < childComponents.length - 1 && (
-            <span className="mx-1">·</span>
-          )}
+          {index < childComponents.length - 1 && <span>·</span>}
         </li>
       ))}
     </ul>

--- a/src/stories/ExtraInfo.stories.tsx
+++ b/src/stories/ExtraInfo.stories.tsx
@@ -1,0 +1,29 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import ExtraInfo from '~/common/components/ExtraInfo';
+
+const meta = {
+  title: 'Common/Components/ExtraInfo',
+  component: ExtraInfo,
+} satisfies Meta<typeof ExtraInfo>;
+
+export default meta;
+
+export const Default: StoryObj<typeof ExtraInfo> = {
+  render: () => (
+    <ExtraInfo>
+      <span>넷플릭스</span>
+      <span>19시간 전</span>
+    </ExtraInfo>
+  ),
+};
+
+export const Array: StoryObj<typeof ExtraInfo> = {
+  render: () => (
+    <ExtraInfo>
+      <span>게시물 10</span>
+      <span>팔로워 10</span>
+      <span>팔로잉 10</span>
+    </ExtraInfo>
+  ),
+};

--- a/src/stories/ExtraInfo.stories.tsx
+++ b/src/stories/ExtraInfo.stories.tsx
@@ -5,13 +5,19 @@ import ExtraInfo from '~/common/components/ExtraInfo';
 const meta = {
   title: 'Common/Components/ExtraInfo',
   component: ExtraInfo,
+  argTypes: {
+    gap: { control: { type: 'range', min: 0, max: 10, step: 1 } },
+  },
+  args: {
+    gap: 1,
+  },
 } satisfies Meta<typeof ExtraInfo>;
 
 export default meta;
 
 export const Default: StoryObj<typeof ExtraInfo> = {
-  render: () => (
-    <ExtraInfo>
+  render: args => (
+    <ExtraInfo {...args}>
       <span>넷플릭스</span>
       <span>19시간 전</span>
     </ExtraInfo>
@@ -19,8 +25,8 @@ export const Default: StoryObj<typeof ExtraInfo> = {
 };
 
 export const Array: StoryObj<typeof ExtraInfo> = {
-  render: () => (
-    <ExtraInfo>
+  render: args => (
+    <ExtraInfo {...args}>
       <span>게시물 10</span>
       <span>팔로워 10</span>
       <span>팔로잉 10</span>


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- close #45 

## ✅ 작업 내용

- 더미데이터를 만들어서 데이터가 모두 잘 출력되는지 확인합니다.
- map 또는 단일 문자열로 제작할 수 있도록 합니다.
- map인 경우에는 마지막 칸에 '・' 기호가 안 붙도록 합니다.

사용 예시)
```
<ExtraInfo>
  <span>게시물 {user.posts.length}</span>
  <span>팔로워 {user.followers.length}</span>
  <span>팔로잉 {user.following.length}</span> 
</ExtraInfo>
```
![스크린샷 2023-12-31 오후 10 03 43](https://github.com/prgrms-fe-devcourse/FEDC5_Owhat_Byunghyun/assets/114740795/714459a1-57fe-4406-af7e-e6e5779efc69)


## 📝 참고 자료


## ♾️ 기타

- 추가로 필요한 작업 내용
