### PR TITLE
feat: Image Upload 컴포넌트 생성

### DIFF
--- a/src/common/components/Upload/index.tsx
+++ b/src/common/components/Upload/index.tsx
@@ -1,0 +1,59 @@
+import { ChangeEvent, ReactNode, useRef, useState } from 'react';
+
+interface UploadProps {
+  id?: string;
+  name?: string;
+  onChange?: (file?: File) => void;
+  children?: ((src: string, file?: File) => ReactNode) | ReactNode;
+}
+
+const Upload = ({ id, name, onChange, children }: UploadProps) => {
+  const [file, setFile] = useState<File>();
+  const [src, setSrc] = useState<string>('');
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  const encodeFileToBase64 = (file: File) => {
+    const reader = new FileReader();
+    reader.readAsDataURL(file);
+    reader.onloadend = () => {
+      setSrc(reader.result as string);
+    };
+  };
+
+  const handleFileChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const newFile = e.target.files?.item(0);
+
+    if (!newFile) return;
+
+    setFile(newFile);
+    onChange?.(newFile);
+    encodeFileToBase64(newFile);
+
+    if (!inputRef.current) return;
+
+    inputRef.current.value = '';
+  };
+
+  const handleFileClick = () => {
+    if (!inputRef.current) return;
+
+    inputRef.current.click();
+  };
+
+  return (
+    <div className="inline-block" onClick={handleFileClick} role="presentation">
+      <input
+        id={id}
+        name={name}
+        type="file"
+        accept="image/*"
+        ref={inputRef}
+        onChange={handleFileChange}
+        hidden
+      />
+      {typeof children === 'function' ? children(src, file) : children}
+    </div>
+  );
+};
+
+export default Upload;

--- a/src/stories/Upload.stories.tsx
+++ b/src/stories/Upload.stories.tsx
@@ -1,0 +1,54 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import Upload from '~/common/components/Upload';
+
+const meta: Meta<typeof Upload> = {
+  title: 'Common/Components/Upload',
+  component: Upload,
+  argTypes: {
+    onChange: { action: 'changed!' },
+  },
+  args: {
+    id: 'image uploader',
+    name: 'image uploader',
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Upload>;
+
+export const Default: Story = {
+  render: args => {
+    return (
+      <Upload {...args}>
+        <button>click</button>
+      </Upload>
+    );
+  },
+};
+
+export const Button: Story = {
+  render: args => {
+    return (
+      <Upload {...args}>
+        {(_, file) => (
+          <button className="rounded-md border-none bg-primary px-4 py-2">
+            {file ? file.name : 'upload'}
+          </button>
+        )}
+      </Upload>
+    );
+  },
+};
+
+export const Preview: Story = {
+  render: args => {
+    return (
+      <Upload {...args}>
+        {src => (
+          <img src={src || 'https://via.placeholder.com/200'} alt="img" />
+        )}
+      </Upload>
+    );
+  },
+};


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- close #42 

## ✅ 작업 내용

- Image Uploader를 구현했습니다.
  - input type file을 이용했습니다.
  - onChange 이벤트가 발생하면 사용자가 선택한 파일을 가져와서 base64 형식으로 인코딩합니다.
  - 자식 컴포넌트는 `string` 타입의 src 주소, `File` 타입인 file을 각각 넘겨 받을 수 있습니다.

