### PR TITLE
feat: Badge 컴포넌트 구현

### DIFF
--- a/src/common/components/Badge/Badge.variants.ts
+++ b/src/common/components/Badge/Badge.variants.ts
@@ -1,0 +1,66 @@
+import { cva } from 'class-variance-authority';
+
+export const badgeVariants = cva(
+  'absolute inline-flex rounded-full shadow-xl',
+  {
+    variants: {
+      corner: {
+        'top-left': 'left-0 top-0 ',
+        'top-right': 'right-0 top-0 ',
+        'bottom-left': 'bottom-0 left-0',
+        'bottom-right': 'bottom-0 right-0',
+      },
+    },
+    defaultVariants: {
+      corner: 'top-right',
+    },
+  },
+);
+export const badgeSizeVariants = cva('', {
+  variants: {
+    size: {
+      xsmall: 'h-2 w-2',
+      small: 'h-3 w-3',
+      medium: 'h-4 w-4',
+      large: 'h-5 w-5',
+      xlarge: 'h-6 w-6',
+    },
+  },
+  defaultVariants: {
+    size: 'large',
+  },
+});
+export const badgePositionVariants = cva('relative flex', {
+  variants: {
+    translateX: {
+      1: '-translate-x-5',
+      2: '-translate-x-4',
+      3: '-translate-x-3',
+      4: '-translate-x-2',
+      5: '-translate-x-1',
+      6: 'translate-x-0',
+      7: 'translate-x-1',
+      8: 'translate-x-2',
+      9: 'translate-x-3',
+      10: 'translate-x-4',
+      11: 'translate-x-5',
+    },
+    translateY: {
+      1: '-translate-y-5',
+      2: '-translate-y-4',
+      3: '-translate-y-3',
+      4: '-translate-y-2',
+      5: '-translate-y-1',
+      6: 'translate-y-0',
+      7: 'translate-y-1',
+      8: 'translate-y-2',
+      9: 'translate-y-3',
+      10: 'translate-y-4',
+      11: 'translate-y-5',
+    },
+  },
+  defaultVariants: {
+    translateX: 1,
+    translateY: 1,
+  },
+});

--- a/src/common/components/Badge/Badge.variants.ts
+++ b/src/common/components/Badge/Badge.variants.ts
@@ -13,7 +13,7 @@ export const badgeVariants = cva(
           'bottom-[15%] right-[10%] translate-x-1/2 translate-y-1/2',
       },
       badgeType: {
-        online: '[&>span]:bg-success',
+        online: '[&>span]:bg-online',
         offline: '[&>span]:bg-gray-700 ',
         alarm: '[&>span]:bg-primary',
       },

--- a/src/common/components/Badge/Badge.variants.ts
+++ b/src/common/components/Badge/Badge.variants.ts
@@ -5,12 +5,12 @@ export const badgeVariants = cva(
   {
     variants: {
       corner: {
-        'top-left': ' left-[10%] top-[15%] -translate-x-1/2 -translate-y-1/2',
-        'top-right': 'right-[10%] top-[15%] -translate-y-1/2 translate-x-1/2',
+        'top-left': ' left-[12%] top-[17%] -translate-x-1/2 -translate-y-1/2',
+        'top-right': 'right-[12%] top-[17%] -translate-y-1/2 translate-x-1/2',
         'bottom-left':
-          'bottom-[15%] left-[10%] -translate-x-1/2 translate-y-1/2',
+          'bottom-[17%] left-[12%] -translate-x-1/2 translate-y-1/2',
         'bottom-right':
-          'bottom-[15%] right-[10%] translate-x-1/2 translate-y-1/2',
+          'bottom-[17%] right-[12%] translate-x-1/2 translate-y-1/2',
       },
       badgeType: {
         online: '[&>span]:bg-online',

--- a/src/common/components/Badge/Badge.variants.ts
+++ b/src/common/components/Badge/Badge.variants.ts
@@ -5,62 +5,30 @@ export const badgeVariants = cva(
   {
     variants: {
       corner: {
-        'top-left': 'left-0 top-0 ',
-        'top-right': 'right-0 top-0 ',
-        'bottom-left': 'bottom-0 left-0',
-        'bottom-right': 'bottom-0 right-0',
+        'top-left': ' left-[10%] top-[15%] -translate-x-1/2 -translate-y-1/2',
+        'top-right': 'right-[10%] top-[15%] -translate-y-1/2 translate-x-1/2',
+        'bottom-left':
+          'bottom-[15%] left-[10%] -translate-x-1/2 translate-y-1/2',
+        'bottom-right':
+          'bottom-[15%] right-[10%] translate-x-1/2 translate-y-1/2',
+      },
+      badgeType: {
+        online: '[&>span]:bg-success',
+        offline: '[&>span]:bg-gray-700 ',
+        alarm: '[&>span]:bg-primary',
+      },
+      size: {
+        xsmall: '[&>:last-child]:h-2 [&>:last-child]:w-2',
+        small: '[&>:last-child]:h-3 [&>:last-child]:w-3',
+        medium: '[&>:last-child]:h-4 [&>:last-child]:w-4',
+        large: '[&>:last-child]:h-5 [&>:last-child]:w-5',
+        xlarge: '[&>:last-child]:h-6 [&>:last-child]:w-6',
       },
     },
     defaultVariants: {
       corner: 'top-right',
+      badgeType: 'online',
+      size: 'large',
     },
   },
 );
-export const badgeSizeVariants = cva('', {
-  variants: {
-    size: {
-      xsmall: 'h-2 w-2',
-      small: 'h-3 w-3',
-      medium: 'h-4 w-4',
-      large: 'h-5 w-5',
-      xlarge: 'h-6 w-6',
-    },
-  },
-  defaultVariants: {
-    size: 'large',
-  },
-});
-export const badgePositionVariants = cva('relative flex', {
-  variants: {
-    translateX: {
-      1: '-translate-x-5',
-      2: '-translate-x-4',
-      3: '-translate-x-3',
-      4: '-translate-x-2',
-      5: '-translate-x-1',
-      6: 'translate-x-0',
-      7: 'translate-x-1',
-      8: 'translate-x-2',
-      9: 'translate-x-3',
-      10: 'translate-x-4',
-      11: 'translate-x-5',
-    },
-    translateY: {
-      1: '-translate-y-5',
-      2: '-translate-y-4',
-      3: '-translate-y-3',
-      4: '-translate-y-2',
-      5: '-translate-y-1',
-      6: 'translate-y-0',
-      7: 'translate-y-1',
-      8: 'translate-y-2',
-      9: 'translate-y-3',
-      10: 'translate-y-4',
-      11: 'translate-y-5',
-    },
-  },
-  defaultVariants: {
-    translateX: 1,
-    translateY: 1,
-  },
-});

--- a/src/common/components/Badge/index.tsx
+++ b/src/common/components/Badge/index.tsx
@@ -3,70 +3,38 @@ import { ComponentProps } from 'react';
 
 import { cn } from '~/utils/cn';
 
-import {
-  badgePositionVariants,
-  badgeSizeVariants,
-  badgeVariants,
-} from './Badge.variants';
+import { badgeVariants } from './Badge.variants';
 
 interface BadgeProps
   extends VariantProps<typeof badgeVariants>,
-    VariantProps<typeof badgeSizeVariants>,
-    VariantProps<typeof badgePositionVariants>,
     ComponentProps<'img'> {
   children: React.ReactNode;
-  badgeType: 'online' | 'offline' | 'alarm';
   isActive?: boolean;
 }
 
 const Badge = ({
   children,
   badgeType,
-  isActive,
+  isActive = true,
   corner,
   size,
   className,
-  translateX,
-  translateY,
   ...props
 }: BadgeProps) => {
-  const getBadgeStyles = () => {
-    switch (badgeType) {
-      case 'online':
-        return 'bg-success';
-      case 'offline':
-        return ' bg-gray-700 animate-none';
-      case 'alarm':
-        return isActive ? 'bg-primary' : 'bg-transparent border-none';
-      default:
-        return '';
-    }
-  };
-
-  const badgeStyles = getBadgeStyles();
-
   return (
-    <div className="relative inline-block " {...props}>
+    <div className="relative inline-block" {...props}>
       {children}
-      <div className={`${cn(badgeVariants({ corner }), className)}`}>
+      {isActive === true && (
         <span
-          className={`${cn(badgePositionVariants({ translateX, translateY }))}`}
+          className={cn(badgeVariants({ corner, badgeType, size }), className)}
         >
-          <span
-            className={`${cn(
-              'absolute inline-flex h-full w-full animate-ping rounded-full opacity-75',
-              badgeStyles,
-            )}`}
-          />
-          <span
-            className={`${cn(
-              badgeSizeVariants({ size }),
-              'relative inline-flex rounded-full border border-gray-300',
-              badgeStyles,
-            )}`}
-          />
+          {badgeType === 'alarm' && (
+            <span className="absolute inline-flex h-full w-full animate-ping rounded-full" />
+          )}
+
+          <span className="relative inline-flex rounded-full border border-white" />
         </span>
-      </div>
+      )}
     </div>
   );
 };

--- a/src/common/components/Badge/index.tsx
+++ b/src/common/components/Badge/index.tsx
@@ -1,0 +1,71 @@
+import { VariantProps } from 'class-variance-authority';
+import { ComponentProps } from 'react';
+
+import { cn } from '~/utils/cn';
+
+import {
+  badgePositionVariants,
+  badgeSizeVariants,
+  badgeVariants,
+} from './Badge.variants';
+
+interface BadgeProps
+  extends VariantProps<typeof badgeVariants>,
+    VariantProps<typeof badgeSizeVariants>,
+    VariantProps<typeof badgePositionVariants>,
+    ComponentProps<'img'> {
+  children: React.ReactNode;
+  badgeType: 'online' | 'offline' | 'alarm';
+  isActive?: boolean;
+}
+
+const Badge = ({
+  children,
+  badgeType,
+  isActive,
+  corner,
+  size,
+  className,
+  translateX,
+  translateY,
+  ...props
+}: BadgeProps) => {
+  const getBadgeStyles = () => {
+    switch (badgeType) {
+      case 'online':
+        return 'bg-success';
+      case 'offline':
+        return ' bg-gray-700 animate-none';
+      case 'alarm':
+        return isActive ? 'bg-primary' : 'bg-transparent border-none';
+      default:
+        return '';
+    }
+  };
+
+  const badgeStyles = getBadgeStyles();
+
+  return (
+    <div className="relative inline-block " {...props}>
+      {children}
+      <div className={`${cn(badgeVariants({ corner }), className)}`}>
+        <span
+          className={`${cn(badgePositionVariants({ translateX, translateY }))}`}
+        >
+          <span
+            className={`absolute inline-flex h-full w-full animate-ping rounded-full opacity-75 ${badgeStyles}`}
+          />
+          <span
+            className={`${cn(
+              badgeSizeVariants({ size }),
+              'relative inline-flex rounded-full border border-gray-300',
+              badgeStyles,
+            )}`}
+          />
+        </span>
+      </div>
+    </div>
+  );
+};
+
+export default Badge;

--- a/src/common/components/Badge/index.tsx
+++ b/src/common/components/Badge/index.tsx
@@ -53,7 +53,10 @@ const Badge = ({
           className={`${cn(badgePositionVariants({ translateX, translateY }))}`}
         >
           <span
-            className={`absolute inline-flex h-full w-full animate-ping rounded-full opacity-75 ${badgeStyles}`}
+            className={`${cn(
+              'absolute inline-flex h-full w-full animate-ping rounded-full opacity-75',
+              badgeStyles,
+            )}`}
           />
           <span
             className={`${cn(

--- a/src/common/components/Badge/index.tsx
+++ b/src/common/components/Badge/index.tsx
@@ -22,7 +22,7 @@ const Badge = ({
   ...props
 }: BadgeProps) => {
   return (
-    <div className="relative inline-block" {...props}>
+    <div className="relative inline-flex" {...props}>
       {children}
       {isActive === true && (
         <span

--- a/src/stories/Badge.stories.tsx
+++ b/src/stories/Badge.stories.tsx
@@ -1,0 +1,58 @@
+import { Meta, StoryObj } from '@storybook/react';
+
+import Avatar from '~/common/components/Avatar';
+import Badge from '~/common/components/Badge';
+import Icon from '~/common/components/Icon';
+export default {
+  title: 'Common/Components/Badge',
+  component: Badge,
+  argTypes: {
+    badgeType: {
+      options: ['online', 'offline', 'alarm'],
+      control: 'inline-radio',
+    },
+    corner: {
+      options: ['top-right', 'top-left', 'bottom-right', 'bottom-left'],
+      control: 'inline-radio',
+    },
+    size: {
+      options: ['xsmall', 'small', 'medium', 'large', 'xlarge'],
+      control: 'inline-radio',
+    },
+    translateX: {
+      control: { type: 'range', min: 1, max: 11, step: 1 },
+    },
+    translateY: {
+      control: { type: 'range', min: 1, max: 11, step: 1 },
+    },
+  },
+  args: {
+    badgeType: 'alarm',
+    corner: 'top-right',
+    translateX: 5,
+    translateY: 7,
+  },
+} satisfies Meta<typeof Badge>;
+
+type Story = StoryObj<typeof Badge>;
+
+export const Default: Story = {
+  render: function Render(args) {
+    return (
+      <Badge {...args}>
+        <Avatar size="small" src="http://picsum.photos/60"></Avatar>
+      </Badge>
+    );
+  },
+};
+export const IconBadge: Story = {
+  render: function Render(args) {
+    return (
+      <Badge {...args}>
+        <div>
+          <Icon id="notifications"></Icon>
+        </div>
+      </Badge>
+    );
+  },
+};

--- a/src/stories/Badge.stories.tsx
+++ b/src/stories/Badge.stories.tsx
@@ -42,7 +42,7 @@ export const BigElement: Story = {
   render: function Render(args) {
     return (
       <Badge {...args}>
-        <Avatar size="screen" src="http://picsum.photos/200"></Avatar>
+        <Avatar size="full" src="http://picsum.photos/200"></Avatar>
       </Badge>
     );
   },

--- a/src/stories/Badge.stories.tsx
+++ b/src/stories/Badge.stories.tsx
@@ -19,18 +19,10 @@ export default {
       options: ['xsmall', 'small', 'medium', 'large', 'xlarge'],
       control: 'inline-radio',
     },
-    translateX: {
-      control: { type: 'range', min: 1, max: 11, step: 1 },
-    },
-    translateY: {
-      control: { type: 'range', min: 1, max: 11, step: 1 },
-    },
   },
   args: {
     badgeType: 'alarm',
     corner: 'top-right',
-    translateX: 5,
-    translateY: 7,
   },
 } satisfies Meta<typeof Badge>;
 
@@ -40,11 +32,22 @@ export const Default: Story = {
   render: function Render(args) {
     return (
       <Badge {...args}>
-        <Avatar size="small" src="http://picsum.photos/60"></Avatar>
+        <Avatar size="small" src="http://picsum.photos/200"></Avatar>
       </Badge>
     );
   },
 };
+
+export const BigElement: Story = {
+  render: function Render(args) {
+    return (
+      <Badge {...args}>
+        <Avatar size="screen" src="http://picsum.photos/200"></Avatar>
+      </Badge>
+    );
+  },
+};
+
 export const IconBadge: Story = {
   render: function Render(args) {
     return (


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- close #63 

## ✅ 작업 내용

- 아바타와 아이콘에 쓰일 badge 컴포넌트 구현
- online, offline, alarm으로 타입은 필수로 받는다.
- online/offline은 isActive값과 무관하게 작동한다. (login상태라면 online, 아니라면 offline으로 출력함)
- alarm은 isActive값에 따라 나타나거나 사라진다. ( 알림의 seen값이 하나라도 있을 경우를 위해)
- top-right, top-left, bottom-left, bottom-right로 원하는 위치에 출력할 수 있음
- badge의 사이즈를 받을 수 있음 (xsmall, small, medium, large, xlarge)
- 사이즈가 달라지면 알림을 원하는 요소와 멀어지게 되는데 이를 위해 translate를 원하는 대로 조정할 수 있게함
- translateX와 translateY를 1~11의 값으로 조정이 가능함 


## 📝 참고 자료

## ♾️ 기타

