### PR TITLE
refactor: Button 컴포넌트 스타일 수정 및 twmerge 문제 수정

### DIFF
--- a/src/common/components/Button/Button.variants.ts
+++ b/src/common/components/Button/Button.variants.ts
@@ -1,17 +1,18 @@
 import { cva } from 'class-variance-authority';
 
 export const buttonVarients = cva(
-  'group relative p-small text-base font-semibold transition-colors',
+  'group relative flex p-small text-base font-semibold transition-colors',
   {
     variants: {
       styleType: {
         primary:
-          'rounded-small bg-primary hover:bg-[#cc6600] focus:outline-none',
+          'rounded-small bg-primary fill-white text-white hover:bg-primary-darker focus:outline-none',
         secondary:
-          'rounded-small bg-white hover:bg-primary hover:fill-white focus:outline-none',
+          'rounded-small bg-white fill-primary text-primary hover:bg-primary hover:fill-white hover:text-white focus:outline-none',
         outline:
-          'rounded-small border border-primary hover:bg-primary focus:outline-none',
-        ghost: 'rounded-small hover:fill-gray-600 focus:outline-none',
+          'focus:outline-nonefill-primary rounded-small border border-primary fill-primary text-primary hover:bg-primary hover:fill-white hover:text-white ',
+        ghost:
+          'rounded-small text-primary hover:fill-gray-600 hover:fill-gray-600 hover:text-primary-darker focus:outline-none',
       },
       disabled: {
         true: 'pointer-events-none border-gray-300 bg-gray-400 fill-white',
@@ -24,21 +25,3 @@ export const buttonVarients = cva(
     },
   },
 );
-export const fontColorVarients = cva('leading-tight', {
-  variants: {
-    styleType: {
-      primary: 'fill-white text-white',
-      secondary: 'text-primary group-hover:fill-white  group-hover:text-white ',
-      outline: 'text-primary group-hover:fill-white  group-hover:text-white ',
-      ghost:
-        'text-primary group-hover:fill-gray-600  group-hover:text-primary-darker ',
-    },
-    disabled: {
-      true: 'pointer-events-none border-gray-300 bg-gray-400 fill-white text-white',
-      false: '',
-    },
-  },
-  defaultVariants: {
-    styleType: 'primary',
-  },
-});

--- a/src/common/components/Button/Button.variants.ts
+++ b/src/common/components/Button/Button.variants.ts
@@ -24,7 +24,7 @@ export const buttonVarients = cva(
     },
   },
 );
-export const fontColorVarients = cva('', {
+export const fontColorVarients = cva('leading-tight', {
   variants: {
     styleType: {
       primary: 'fill-white text-white',

--- a/src/common/components/Button/Button.variants.ts
+++ b/src/common/components/Button/Button.variants.ts
@@ -1,21 +1,44 @@
 import { cva } from 'class-variance-authority';
 
 export const buttonVarients = cva(
-  `text-md relative px-4 py-2 font-semibold transition-colors`,
+  'group relative p-small text-base font-semibold transition-colors',
   {
     variants: {
       styleType: {
         primary:
-          'rounded-lg bg-primary text-white hover:bg-[#cc6600] focus:outline-none',
+          'rounded-small bg-primary hover:bg-[#cc6600] focus:outline-none',
         secondary:
-          'rounded-md bg-white text-primary hover:bg-primary hover:text-white focus:outline-none',
+          'rounded-small bg-white hover:bg-primary hover:fill-white focus:outline-none',
         outline:
-          'rounded-md border border-primary text-primary hover:bg-primary hover:text-white focus:outline-none',
-        ghost: 'hover:fill-gray-600 focus:outline-none rounded-md text-primary',
+          'rounded-small border border-primary hover:bg-primary focus:outline-none',
+        ghost: 'rounded-small hover:fill-gray-600 focus:outline-none',
+      },
+      disabled: {
+        true: 'pointer-events-none border-gray-300 bg-gray-400 fill-white',
+        false: '',
       },
     },
     defaultVariants: {
       styleType: 'primary',
+      disabled: false,
     },
   },
 );
+export const fontColorVarients = cva('', {
+  variants: {
+    styleType: {
+      primary: 'fill-white text-white',
+      secondary: 'text-primary group-hover:fill-white  group-hover:text-white ',
+      outline: 'text-primary group-hover:fill-white  group-hover:text-white ',
+      ghost:
+        'text-primary group-hover:fill-gray-600  group-hover:text-primary-darker ',
+    },
+    disabled: {
+      true: 'pointer-events-none border-gray-300 bg-gray-400 fill-white text-white',
+      false: '',
+    },
+  },
+  defaultVariants: {
+    styleType: 'primary',
+  },
+});

--- a/src/common/components/Button/index.tsx
+++ b/src/common/components/Button/index.tsx
@@ -4,13 +4,12 @@ import { ComponentProps } from 'react';
 import Loading from '~/common/components/Loading';
 import { cn } from '~/utils/cn';
 
-import { buttonVarients, fontColorVarients } from './Button.variants';
+import { buttonVarients } from './Button.variants';
 
 //TODO: invisible 사용고려 - loading을 감싸는 rounded가 통일 되지않아 튀어나오는 버그 -> main 머지 후 해결 가능
 export interface ButtonProps
   extends ComponentProps<'button'>,
-    VariantProps<typeof buttonVarients>,
-    VariantProps<typeof fontColorVarients> {
+    VariantProps<typeof buttonVarients> {
   children: React.ReactNode;
   loading?: boolean;
   fullwidth?: boolean;
@@ -42,10 +41,7 @@ const Button = ({
         </div>
       )}
       <span
-        className={cn(
-          loading ? 'invisible' : 'flex',
-          fontColorVarients({ styleType, disabled }),
-        )}
+        className={cn(loading ? 'invisible' : 'inline-block', 'text-inherit')}
       >
         {children}
       </span>

--- a/src/common/components/Button/index.tsx
+++ b/src/common/components/Button/index.tsx
@@ -43,8 +43,7 @@ const Button = ({
       )}
       <span
         className={cn(
-          loading ? 'invisible' : 'inline-block',
-          'align-middle',
+          loading ? 'invisible' : 'flex',
           fontColorVarients({ styleType, disabled }),
         )}
       >

--- a/src/common/components/Button/index.tsx
+++ b/src/common/components/Button/index.tsx
@@ -4,12 +4,13 @@ import { ComponentProps } from 'react';
 import Loading from '~/common/components/Loading';
 import { cn } from '~/utils/cn';
 
-import { buttonVarients } from './Button.variants';
+import { buttonVarients, fontColorVarients } from './Button.variants';
 
 //TODO: invisible 사용고려 - loading을 감싸는 rounded가 통일 되지않아 튀어나오는 버그 -> main 머지 후 해결 가능
 export interface ButtonProps
-  extends VariantProps<typeof buttonVarients>,
-    ComponentProps<'button'> {
+  extends ComponentProps<'button'>,
+    VariantProps<typeof buttonVarients>,
+    VariantProps<typeof fontColorVarients> {
   children: React.ReactNode;
   loading?: boolean;
   fullwidth?: boolean;
@@ -29,10 +30,9 @@ const Button = ({
     <button
       disabled={disabled || loading}
       className={cn(
-        buttonVarients({ styleType }),
+        buttonVarients({ styleType, disabled }),
         className,
         fullwidth && 'w-full',
-        disabled ? 'border-gray-300 bg-gray-300 text-white' : '',
       )}
       {...props}
     >
@@ -42,7 +42,11 @@ const Button = ({
         </div>
       )}
       <span
-        className={`${loading ? 'invisible' : 'inline-block'} align-baseline`}
+        className={cn(
+          loading ? 'invisible' : 'inline-block',
+          'align-middle',
+          fontColorVarients({ styleType, disabled }),
+        )}
       >
         {children}
       </span>

--- a/src/stories/Button.stories.tsx
+++ b/src/stories/Button.stories.tsx
@@ -35,23 +35,17 @@ export const Default: Story = {
     return (
       <>
         <div>
-          <Button {...args} styleType={'primary'}>
-            button
-          </Button>
+          <Button {...args}>button</Button>
         </div>
         <div>
-          <Button {...args} styleType={'secondary'}>
-            완료
-          </Button>
+          <Button {...args}>완료</Button>
         </div>
 
         <div>
-          <Button {...args} styleType={'outline'}>
-            작성
-          </Button>
+          <Button {...args}>작성</Button>
         </div>
         <div>
-          <Button {...args} styleType={'ghost'}>
+          <Button {...args}>
             <Icon id="search"></Icon>
           </Button>
         </div>


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- close #66 

## ✅ 작업 내용

- [x] hover:text-white가 적용이 안되는 문제 해결
- [x]  disabled에서는 hover가 작동하지 않도록 구현
- [x]  크기나 색상 값은 tailwind.config에서 사용되는 단위로 재구성(디자인 통일)

## 📝 참고 자료

### Tailwind의 twmerge의 중복제거의 한계 때문에 생긴 문제

text-size와 text-color를 적용하고 twmerge를 사용했을 때 실제로는 하나의 속성만 적용되는 문제가 있었다.
이는 Tailwind의 twmerge의 문제로 나타났고,
stackoverflow에서 twmerge 개발자의 답변으로 "공식 문서의 예시를 참고하여 커스텀을 추가"하거나, "상수로 관리해서 tailwind에서 정의한 기본 속성 활용하기의 두 가지 방법"을 추천했다.

나는 button에서 스타일을 적용하고 button안의 span이 상속받고 있던 상황이어서 
twmerge에서 tailwind에 자식선택자를 이용해 해결했다.

하지만 그렇게 한다면 button에 적용했던 hover와 같은 text-color를 바꾸는 코드가 먹히지 않게 되었다.
왜냐하면 자식선택자로 span의 색상을 고정했기 때문이다.
그래서 cva를 따로 만들어서 button과 span의 cn을 분리해줬다.

[참고 링크](
https://velog.io/@doggopawer/tailwind-%EC%A4%91%EC%B2%A9-%ED%81%B4%EB%9E%98%EC%8A%A4-%EC%98%A4%EB%A5%98)


## ♾️ 기타

