### PR TITLE
feat: Page Layout 컴포넌트 생성

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React + TS</title>
+    <title>Owhat! | OTT에 대한 정보를 한 번에!</title>
   </head>
   <body>
     <div id="root"></div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { RouterProvider } from 'react-router-dom';
 
+import LayoutProvider from './common/components/Layout';
 import { router } from './Router';
 
 const queryClient = new QueryClient({
@@ -18,7 +19,9 @@ const queryClient = new QueryClient({
 function App() {
   return (
     <QueryClientProvider client={queryClient}>
-      <RouterProvider router={router} />
+      <LayoutProvider>
+        <RouterProvider router={router} />
+      </LayoutProvider>
       <ReactQueryDevtools initialIsOpen={false} />
     </QueryClientProvider>
   );

--- a/src/common/components/Group/Group.variants.ts
+++ b/src/common/components/Group/Group.variants.ts
@@ -27,7 +27,7 @@ export const groupVariants = cva(``, {
     },
     grow: {
       true: '[&>*]:grow-1 flex-nowrap [&>*]:w-full',
-      false: '[&>*]:grow-0',
+      false: '',
     },
   },
   defaultVariants: {

--- a/src/common/components/Header/index.tsx
+++ b/src/common/components/Header/index.tsx
@@ -10,14 +10,10 @@ export interface HeaderProps {
 
 const Header = ({ title, left, right }: HeaderProps) => {
   return (
-    <header className="relative mb w-full border-b py text-center">
-      <div className="absolute left-0 top-1/2 w-max max-w-16 -translate-y-1/2 overflow-hidden text-ellipsis text-nowrap">
-        {left}
-      </div>
+    <header className="mb grid w-full grid-cols-[1fr,4fr,1fr] items-center border-b px-small py text-center">
+      <span className="justify-self-start">{left}</span>
       {title ? <b>{title}</b> : <Logo />}
-      <div className="absolute right-0 top-1/2 w-max max-w-16 -translate-y-1/2 overflow-hidden text-ellipsis text-nowrap">
-        {right}
-      </div>
+      <span className="justify-self-end">{right}</span>
     </header>
   );
 };

--- a/src/common/components/Header/index.tsx
+++ b/src/common/components/Header/index.tsx
@@ -1,0 +1,21 @@
+import { ReactNode } from 'react';
+
+import Logo from '../Logo';
+
+export interface HeaderProps {
+  title?: ReactNode;
+  left: ReactNode;
+  right: ReactNode;
+}
+
+const Header = ({ title, left, right }: HeaderProps) => {
+  return (
+    <header className="relative mb w-full border-b py text-center">
+      <div className="absolute left-0 top-1/2 -translate-y-1/2">{left}</div>
+      {title ? <b>{title}</b> : <Logo />}
+      <div className="absolute right-0 top-1/2 -translate-y-1/2">{right}</div>
+    </header>
+  );
+};
+
+export default Header;

--- a/src/common/components/Header/index.tsx
+++ b/src/common/components/Header/index.tsx
@@ -11,9 +11,13 @@ export interface HeaderProps {
 const Header = ({ title, left, right }: HeaderProps) => {
   return (
     <header className="relative mb w-full border-b py text-center">
-      <div className="absolute left-0 top-1/2 -translate-y-1/2">{left}</div>
+      <div className="absolute left-0 top-1/2 w-max max-w-16 -translate-y-1/2 overflow-hidden text-ellipsis text-nowrap">
+        {left}
+      </div>
       {title ? <b>{title}</b> : <Logo />}
-      <div className="absolute right-0 top-1/2 -translate-y-1/2">{right}</div>
+      <div className="absolute right-0 top-1/2 w-max max-w-16 -translate-y-1/2 overflow-hidden text-ellipsis text-nowrap">
+        {right}
+      </div>
     </header>
   );
 };

--- a/src/common/components/Layout/index.tsx
+++ b/src/common/components/Layout/index.tsx
@@ -1,0 +1,53 @@
+import { createContext, ReactNode, useEffect, useState } from 'react';
+
+import Header, { type HeaderProps } from '../Header';
+
+interface ILayoutContext extends HeaderProps {
+  changeMeta: ({ title, left, right }: HeaderProps) => void;
+}
+
+interface LayoutProviderProps {
+  children: ReactNode;
+}
+
+export const LayoutContext = createContext<ILayoutContext>(
+  {} as ILayoutContext,
+);
+
+const LayoutProvider = ({ children }: LayoutProviderProps) => {
+  const [template, setTemplate] = useState<HeaderProps>({
+    title: '',
+    left: null,
+    right: null,
+  });
+
+  const changeMeta = ({
+    title,
+    left,
+    right,
+  }: Omit<ILayoutContext, 'changeMeta'>) => {
+    setTemplate({
+      ...template,
+      title: title || template.title,
+      left: left || template.left,
+      right: right || template.right,
+    });
+  };
+
+  useEffect(() => {
+    document.title = `${
+      template.title || 'Owhat!'
+    } | OTT에 대한 정보를 한 번에!`;
+  }, [template.title]);
+
+  return (
+    <LayoutContext.Provider value={{ ...template, changeMeta }}>
+      <main className="max-w-layout px">
+        <Header {...template} />
+        {children}
+      </main>
+    </LayoutContext.Provider>
+  );
+};
+
+export default LayoutProvider;

--- a/src/common/components/Layout/index.tsx
+++ b/src/common/components/Layout/index.tsx
@@ -21,11 +21,7 @@ const LayoutProvider = ({ children }: LayoutProviderProps) => {
     right: null,
   });
 
-  const changeMeta = ({
-    title,
-    left,
-    right,
-  }: Omit<ILayoutContext, 'changeMeta'>) => {
+  const changeMeta = ({ title, left, right }: HeaderProps) => {
     setTemplate({
       ...template,
       title: title || template.title,

--- a/src/common/components/Logo/index.tsx
+++ b/src/common/components/Logo/index.tsx
@@ -2,7 +2,7 @@ import Text from '../Text';
 
 const Logo = () => {
   return (
-    <Text elementType="span" isLogo className="cursor-pointer text-primary">
+    <Text isLogo className="text-primary">
       Owhat
     </Text>
   );

--- a/src/common/components/Logo/index.tsx
+++ b/src/common/components/Logo/index.tsx
@@ -2,7 +2,7 @@ import Text from '../Text';
 
 const Logo = () => {
   return (
-    <Text isLogo className="cursor-pointer text-primary">
+    <Text elementType="span" isLogo className="cursor-pointer text-primary">
       Owhat
     </Text>
   );

--- a/src/common/components/Logo/index.tsx
+++ b/src/common/components/Logo/index.tsx
@@ -1,0 +1,11 @@
+import Text from '../Text';
+
+const Logo = () => {
+  return (
+    <Text isLogo className="cursor-pointer text-primary">
+      Owhat
+    </Text>
+  );
+};
+
+export default Logo;

--- a/src/common/hooks/useLayout.ts
+++ b/src/common/hooks/useLayout.ts
@@ -1,0 +1,13 @@
+import { useContext } from 'react';
+
+import { LayoutContext } from '~/common/components/Layout';
+
+const useLayout = () => {
+  const context = useContext(LayoutContext);
+
+  if (!context) throw new Error('Context가 없어요!');
+
+  return context;
+};
+
+export default useLayout;

--- a/src/stories/Group.stories.tsx
+++ b/src/stories/Group.stories.tsx
@@ -33,7 +33,7 @@ const meta: Meta<typeof Group> = {
     },
   },
   args: {
-    direction: 'row',
+    direction: 'rows',
     position: 'left',
     align: 'start',
     inline: false,

--- a/src/stories/Layout.stories.tsx
+++ b/src/stories/Layout.stories.tsx
@@ -1,0 +1,72 @@
+/* eslint-disable react-hooks/rules-of-hooks */
+import { Meta, StoryObj } from '@storybook/react';
+import { useEffect } from 'react';
+
+import Icon from '~/common/components/Icon';
+import LayoutProvider from '~/common/components/Layout';
+import useLayout from '~/common/hooks/useLayout';
+
+const meta = {
+  title: 'Common/Components/Layout',
+  args: {
+    page: 'home',
+  },
+  argTypes: {
+    page: {
+      control: 'inline-radio',
+      options: ['home', 'detail'],
+    },
+  },
+  decorators: Story => (
+    <LayoutProvider>
+      <Story />
+    </LayoutProvider>
+  ),
+} satisfies Meta<{ page: 'home' | 'detail' }>;
+
+export default meta;
+
+export const Default: StoryObj<{ page: 'home' | 'detail' }> = {
+  render: args => (
+    <section>
+      <>{args.page === 'home' ? <HomePage /> : <DetailPage />}</>
+      <div>{args.page}</div>
+    </section>
+  ),
+};
+
+function HomePage() {
+  const { changeMeta } = useLayout();
+
+  useEffect(() => {
+    changeMeta({
+      title: 'Main',
+      left: <div></div>,
+      right: <button className="text-primary">로그인</button>,
+    });
+  }, []);
+
+  return (
+    <section>
+      <div>Home 페이지입니다.</div>
+    </section>
+  );
+}
+
+function DetailPage() {
+  const { changeMeta } = useLayout();
+
+  useEffect(() => {
+    changeMeta({
+      title: 'Detail',
+      left: <Icon id="arrow-back" className="h-4 w-4" />,
+      right: <Icon id="search" />,
+    });
+  }, []);
+
+  return (
+    <section>
+      <div>Detail 페이지입니다.</div>
+    </section>
+  );
+}


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- close #71 

## ✅ 작업 내용

- Header 컴포넌트를 생성했습니다.
- Page Layout 컴포넌트를 생성했습니다. 해당 컴포넌트는 다음과 같은 역할을 할 수 있습니다.
  - 현재 페이지의 document title을 지정합니다. 
  - 페이지의 헤더 컴포넌트에 title, left, right 컴포넌트를 지정할 수 있습니다.

## 📝 참고 자료

- Page Layout을 변경하기 위해서는 다음과 같이 작성할 수 있습니다.

```tsx
// home page
const HomePage = () => {
  const { changeMeta } = useLayout();

  useEffect(() => {
    changeMeta({
      left: null,
      right: <button>완료</button>,
    });
  }, []);

  return <section>home</section>
}
```

- 걱정되는 부분은 현재 페이지에 최초 진입했을 때 한 번만 changeMeta 함수를 호출해주면 됩니다. 그래서 useEffect를 사용했는데, 의존성 배열에 changeMeta 함수를 넣으라는 warning이 계속 발생합니다. 그래서 넣어주면 오히려 useEffect에서 setState 함수를 실행하지 말라는 에러가 발생하고 무한 리렌더링이 발생합니다. 이걸 해결하기 위해서는 useEffect를 사용하라는 모순이 발생해서 일단은 빈 의존성 배열을 사용했습니다. 이 부분에 대해서는 나중에 더 알아보면 좋을 것 같습니다!

## ♾️ 기타

- 추가로 필요한 작업 내용
