### PR TITLE
refactor: Avatar 컴포넌트 스타일 수정 및 드래그 방지 추가

### DIFF
--- a/src/common/components/Avatar/Avatar.varients.ts
+++ b/src/common/components/Avatar/Avatar.varients.ts
@@ -1,9 +1,7 @@
 import { cva } from 'class-variance-authority';
 
 export const avatarVariants = cva(
-  `
-relative inline-block overflow-hidden border border-solid border-gray-300 bg-gray-200
-`,
+  'relative inline-block overflow-hidden bg-gray-200 ring-1 ring-gray-400 ring-offset-2',
   {
     variants: {
       shape: {

--- a/src/common/components/Avatar/index.tsx
+++ b/src/common/components/Avatar/index.tsx
@@ -42,6 +42,7 @@ const Avatar = ({
         src={src}
         alt={alt}
         placeholder={placeholder}
+        draggable="false"
         className={`${
           loaded ? 'opacity-100' : 'opacity-0'
         } select-none transition-opacity duration-200 ease-out`}

--- a/src/stories/Avatar.stories.tsx
+++ b/src/stories/Avatar.stories.tsx
@@ -1,5 +1,6 @@
 import { Meta, StoryObj } from '@storybook/react';
 
+import DEFAULT_IMAGE from '~/assets/images/default_profile.webp';
 import Avatar from '~/common/components/Avatar';
 
 export default {
@@ -16,7 +17,7 @@ export default {
     },
   },
   args: {
-    src: 'src/assets/images/default_profile.webp',
+    src: DEFAULT_IMAGE,
     size: 'small',
     shape: 'circle',
   },


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- close #67 

## ✅ 작업 내용

- Avatar 컴포넌트 border-solid 적용으로 인한 간격 문제 해결
- Avatar 컴포넌트에서는 Image 컴포넌트의 요소가 드래그 안되게 함
- Avatar 컴포넌트 스타일 수정

## 📝 참고 자료



## ♾️ 기타

현재 로컬에서는 default image가 정상적으로 보이는데
CI/CD로 배포된 링크에서는 default image가 안보이는 현상

**로컬**
![image](https://github.com/prgrms-fe-devcourse/FEDC5_Owhat_Byunghyun/assets/90139306/083f33c4-298f-4a9d-9aba-4509e3f297cc)

**배포**
![image](https://github.com/prgrms-fe-devcourse/FEDC5_Owhat_Byunghyun/assets/90139306/febb6bbc-d386-4aee-a2d8-dc1dd49701dd)
