### PR TITLE
fix: text 컴포넌트에 text-inherit 추가, global.css의 text-black 제거

### DIFF
--- a/src/common/components/Text/Text.variants.ts
+++ b/src/common/components/Text/Text.variants.ts
@@ -1,6 +1,6 @@
 import { cva } from 'class-variance-authority';
 
-export const textVariants = cva(`text-black`, {
+export const textVariants = cva(`text-black text-inherit`, {
   variants: {
     size: {
       xsmall: `text-caption`,

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -11,7 +11,7 @@
 
 @layer base {
   * {
-    @apply m-0 p-0 font-sans text-black  outline-none;
+    @apply m-0 p-0 font-sans outline-none;
   }
 
   h1 {


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- close #78 

## ✅ 작업 내용

- global.css의 전체 선택자에서 'text-black' 삭제
- text 컴포넌트 기본값으로 text-inherit 추가

## 📝 참고 자료

## ♾️ 기타

- 추가로 필요한 작업 내용
