### PR TITLE
fix: button fullWidth 기능 수정 및 스타일 수정

### DIFF
--- a/src/common/components/Button/Button.variants.ts
+++ b/src/common/components/Button/Button.variants.ts
@@ -1,18 +1,18 @@
 import { cva } from 'class-variance-authority';
 
 export const buttonVarients = cva(
-  'group relative flex p-small text-base font-semibold transition-colors',
+  'relative flex justify-center border p-small text-base font-semibold transition-colors',
   {
     variants: {
       styleType: {
         primary:
-          'rounded-small bg-primary fill-white text-white hover:bg-primary-darker focus:outline-none',
+          'rounded-small  border-transparent bg-primary fill-white text-white hover:bg-primary-darker focus:outline-none',
         secondary:
-          'rounded-small bg-white fill-primary text-primary hover:bg-primary hover:fill-white hover:text-white focus:outline-none',
+          'rounded-small  border-transparent  bg-white fill-primary text-primary hover:bg-primary hover:fill-white hover:text-white focus:outline-none',
         outline:
-          'focus:outline-nonefill-primary rounded-small border border-primary fill-primary text-primary hover:bg-primary hover:fill-white hover:text-white ',
+          'focus:outline-nonefill-primary box-border rounded-small border border-primary fill-primary text-primary hover:bg-primary hover:fill-white hover:text-white ',
         ghost:
-          'rounded-small text-primary hover:fill-gray-600 hover:fill-gray-600 hover:text-primary-darker focus:outline-none',
+          'rounded-small border-transparent  text-primary hover:fill-gray-600 hover:fill-gray-600 hover:text-primary-darker focus:outline-none',
       },
       disabled: {
         true: 'pointer-events-none border-gray-300 bg-gray-400 fill-white',

--- a/src/common/components/Button/index.tsx
+++ b/src/common/components/Button/index.tsx
@@ -40,9 +40,7 @@ const Button = ({
           <Loading />
         </div>
       )}
-      <span
-        className={cn(loading ? 'invisible' : 'inline-block', 'text-inherit')}
-      >
+      <span className={cn(loading ? 'invisible' : 'visible', 'text-inherit')}>
         {children}
       </span>
     </button>


### PR DESCRIPTION
## 🌍 이슈 번호 

- close #82 

## ✅ 작업 내용

- fullwidth를 적용했을 때 버튼안의 요소가 가운데 정렬되지않는 문제 해결
-  flex를 주고 justify-center로 통일함, 그리고 로딩 요소가 나오면 children 콘텐츠는 invisible : visible로 변경
- 만약 버튼의 type이 state로 인해서 바뀌는 로직이 있다면 버튼이 border값으로 인해 크기가 통일되지않은 문제를 모든 button type에 border를 주고, border의 색상을 transparent로 적용함

## 📝 참고 자료

## ♾️ 기타

