### PR TITLE
fix: userinfo 컴포넌트와 스토리북 수정

### DIFF
--- a/src/common/components/UserInfo/index.tsx
+++ b/src/common/components/UserInfo/index.tsx
@@ -13,6 +13,7 @@ interface UserInfoProps {
   author: string;
   channel?: string;
   createdAt: string;
+  isMyAccount?: boolean;
 }
 
 const UserInfo = ({
@@ -21,14 +22,18 @@ const UserInfo = ({
   author,
   channel,
   createdAt,
+  isMyAccount = false,
 }: UserInfoProps) => {
   return (
-    <Group spacing={'sm'} align={'center'}>
-      <Link to={`/account/${_id}`} className="flex items-center">
+    <Group spacing={'md'} align={'center'}>
+      <Link
+        to={isMyAccount ? `/account/${_id}` : ''}
+        className="flex items-center"
+      >
         <Avatar src={profileImage} size="auto" className="h-14 w-14"></Avatar>
       </Link>
       <Group spacing={2} direction={'columns'}>
-        <Link to={`/account/${_id}`}>
+        <Link to={isMyAccount ? `/account/${_id}` : ''}>
           <Text strong>{author}</Text>
         </Link>
         <ExtraInfo>

--- a/src/stories/UserInfo.stories.tsx
+++ b/src/stories/UserInfo.stories.tsx
@@ -27,7 +27,7 @@ export default meta;
 
 export const Default: StoryObj<typeof UserInfo> = {
   args: {
-    _id: '6169b2d3d5f8f3e7e8e5f5f5',
+    _id: '12315613213',
     author: '홍길동',
     channel: '넷플릭스',
   },
@@ -35,7 +35,7 @@ export const Default: StoryObj<typeof UserInfo> = {
 
 export const Comment: StoryObj<typeof UserInfo> = {
   args: {
-    _id: '6169b2d3d5f8f3e7e8e5f5f5',
+    _id: '1234567890',
     author: '홍길동',
   },
 };


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- close #106 

## ✅ 작업 내용

- userinfo 컴포넌트에 ismypage props 추가
- ismypage일 경우 페이지 이동 막기
- 아바타와 정보 사이 간격 sm => md로 수정
- storybook id args 변경

## 📝 참고 자료

#105 

## ♾️ 기타
