### PR TITLE
refactor: Carousel 모바일 터치 이벤트 추가 구현

### DIFF
--- a/src/common/components/Carousel/index.tsx
+++ b/src/common/components/Carousel/index.tsx
@@ -74,6 +74,9 @@ const Carousel = ({
         onMouseDown={handleMouseDown}
         onMouseMove={handleMouseMove}
         onMouseUp={handleMouseUp}
+        onTouchStart={handleMouseDown}
+        onTouchMove={handleMouseMove}
+        onTouchEnd={handleMouseUp}
         onMouseLeave={handleMouseUp}
       >
         <Group spacing={groupGap} align="center" position="center" noWrap>

--- a/src/common/components/Carousel/useDragScroll.ts
+++ b/src/common/components/Carousel/useDragScroll.ts
@@ -6,8 +6,8 @@ interface UseDragScrollParams {
 }
 
 interface UseDragScrollResult {
-  handleMouseDown: (e: React.MouseEvent) => void;
-  handleMouseMove: (e: React.MouseEvent) => void;
+  handleMouseDown: (e: React.MouseEvent | React.TouchEvent) => void;
+  handleMouseMove: (e: React.MouseEvent | React.TouchEvent) => void;
   handleMouseUp: () => void;
   buttonScrollLeft: () => void;
   buttonScrollRight: () => void;
@@ -31,23 +31,26 @@ const useDragScroll = ({
     isRightButtonActive: true,
   });
 
-  const handleMouseDown = (e: React.MouseEvent) => {
+  const handleMouseDown = (e: React.MouseEvent | React.TouchEvent) => {
     if (!containerRef.current) return;
-    e.preventDefault();
+
     e.stopPropagation();
 
+    const clientX = 'touches' in e ? e.touches[0].clientX : e.clientX;
     const { offsetLeft, scrollLeft } = containerRef.current;
 
     setIsDragging(true);
-    setStartX(e.pageX - offsetLeft);
+    setStartX(clientX - offsetLeft);
     setScrollLeft(scrollLeft || 0);
   };
 
-  const handleMouseMove = (e: React.MouseEvent) => {
+  const handleMouseMove = (e: React.MouseEvent | React.TouchEvent) => {
     if (!isDragging || !containerRef.current) return;
+
+    const clientX = 'touches' in e ? e.touches[0].clientX : e.clientX;
     const { offsetLeft } = containerRef.current;
 
-    const x = e.pageX - offsetLeft;
+    const x = clientX - offsetLeft;
     const walk = (x - startX) * 2;
     containerRef.current.scrollLeft = scrollLeft - walk;
   };

--- a/src/stories/Carousel.stories.tsx
+++ b/src/stories/Carousel.stories.tsx
@@ -34,7 +34,10 @@ export const Default: Story = {
     return (
       <Carousel className="border-y-2" {...args}>
         {Array.from(new Array(20), (_, k) => k).map(i => (
-          <div className="relative inline-block select-none overflow-hidden rounded-full bg-gray-200 ring-1 ring-gray-400 ring-offset-2">
+          <div
+            key={i}
+            className="relative inline-block select-none overflow-hidden rounded-full bg-gray-200 ring-1 ring-gray-400 ring-offset-2"
+          >
             <img
               key={i}
               alt="아바타"


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- close #112 

## ✅ 작업 내용

- 모바일 터치 이벤트 추가 구현
- 기존에 존재했던 passive 가 true일 때 마우스 이벤트 오류 해결
- storybook에서 존재하던 key에러 해결

## 📝 참고 자료



## ♾️ 기타

### 브라우저에서 "passive" 속성이 true로 설정된 이벤트 리스너에서 preventDefault를 호출하려고 할 때 발생하는 오류
**오류** : ```Unable to preventDefault inside passive event listener invocation``` 

 passive 속성이 true로 설정되면 브라우저는 해당 이벤트 리스너가 페이지 스크롤 성능을 향상시키기 위해 호출되는 것으로 간주하고, preventDefault를 호출할 수 없도록 한다.
일반적으로 스크롤 관련 이벤트 예를 들어 touchmove와 같은 이벤트 리스너에서 preventDefault를 호출하는 것은 
스크롤을 방지하고자 하는 목적인데 
브라우저는 성능 이슈를 방지하기 위해 "passive" 속성이 true로 설정된 경우에는 preventDefault를 허용하지 않는다고 한다.

코드에서는 passive 속성을 지정하지 않았지만 아래와 같은 이유로 문제가 생겨난다.

> passive 속성이 false인 경우에 touchstart, touchmove와 같은 이벤트가 발생하면 preventDefault를 이용하여 실제 이벤트 자체를 막을 수 있기 때문에, 브라우저는 scroll을 계속 할지 안할지를 매번 감시해야만 한다.
> 하지만, passive 속성이 true일 경우에는 preventDefault를 이용하여 scroll 이벤트를 막지 않겠다고 브라우저에게 이야기하는 것과 같다. 따라서, 이 룰을 어기면 브라우저는 가차없이 다음과 같은 에러를 던진다.
> 다행이 passive 속성의 기본값은 false 이기 때문에, 기존 코드는 문제가 되지 않는다.
> 하지만…
> Chrome 54+ 부터 EventListenerOptions의 passive 속성이 특별한 상황일 경우에는 기본값이 true로 설정된다.
> 
> document또는 body에 이벤트 리스너를 추가할때, touchstart, touchmove와 같이 스크롤이 블록되는 이벤트인 경우, passive의 기본 속성값은 true가 된다.
[passive 속성이 기본값?](https://m.blog.naver.com/PostView.naver?isHttpsRedirect=true&blogId=crazymonlong&logNo=221580029479)