### PR TITLE
refactor: 로그아웃 캐싱 제거, 회원가입 버그, ExtraInfo 가운데 정렬, 닉네임 정규표현식 문제 해결

### DIFF
--- a/src/common/components/ExtraInfo/index.tsx
+++ b/src/common/components/ExtraInfo/index.tsx
@@ -19,7 +19,10 @@ const ExtraInfo = ({ className, gap = 1, children, ...props }: TextProps) => {
       {childComponents.map((child, index) => (
         <li
           key={index}
-          className={cn(extraInfoVariants({ gap }), 'text-base-small')}
+          className={cn(
+            extraInfoVariants({ gap }),
+            'items-center align-middle text-base-small ',
+          )}
         >
           {child}
           {index < childComponents.length - 1 && <span>·</span>}

--- a/src/common/hooks/mutations/useLogout/index.ts
+++ b/src/common/hooks/mutations/useLogout/index.ts
@@ -1,4 +1,4 @@
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
 
 import { postLogout } from '~/api/register';
@@ -7,12 +7,14 @@ import { BrowserStorage } from '~/utils/storage';
 
 export const useLogout = () => {
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
 
   const { mutate: logout } = useMutation({
     mutationFn: postLogout,
     onSuccess: () => {
       const storage = new BrowserStorage(OWHAT_TOKEN);
       storage.clear();
+      queryClient.invalidateQueries();
 
       navigate('/');
       // 토스트 컴포넌트 추가 시 alert 대신 사용

--- a/src/constants/message.ts
+++ b/src/constants/message.ts
@@ -1,0 +1,13 @@
+export const ERROR = Object.freeze({
+  NAME_INVALID:
+    '공백,특수문자 제외 3~8자 이상 입력해주세요. (한글은 자음과 모음 조합으로 입력해주세요.)',
+  PASSWORD_INVAILD:
+    '비밀번호는 8자 이상이어야 하며, 영문 대/소문자, 숫자, 특수문자를 포함해야 합니다.',
+  PASSWORD_NOT_MATCH: '비밀번호가 일치하지 않습니다.',
+  DUPLICATE_EMAIL: '이메일이 이미 사용 중입니다.',
+  EMAIL_VALID: '올바른 이메일을 입력해주세요',
+});
+
+export const MESSAGE = Object.freeze({
+  POSSIBLE_EMAIL: '가입 가능한 이메일입니다.',
+});

--- a/src/pages/register/components/RegisterForm/index.tsx
+++ b/src/pages/register/components/RegisterForm/index.tsx
@@ -5,6 +5,7 @@ import Group from '~/common/components/Group';
 import Text from '~/common/components/Text';
 import { useUserListQuery } from '~/common/hooks/queries/userUserList';
 import useForm from '~/common/hooks/useForm';
+import { ERROR, MESSAGE } from '~/constants/message';
 import {
   isValidEmail,
   isValidPassword,
@@ -78,7 +79,7 @@ const RegisterForm = ({
       className="absolute right-0 top-0 z-10 translate-y-[7%] text-sm"
       disabled={
         !isValid.email ||
-        (emailCheckMessage === '가입 가능한 이메일입니다.' && !isEmailDuplicate)
+        (emailCheckMessage === MESSAGE.POSSIBLE_EMAIL && !isEmailDuplicate)
       }
     >
       중복 확인
@@ -118,7 +119,7 @@ const RegisterForm = ({
           onChange={handleChange}
           value={values.username}
           isValid={isValid.username}
-          errorMessage="이름을 3~8 글자로 공백없이 입력해주세요."
+          errorMessage={ERROR.NAME_INVALID}
         />
         <FormField
           type="password"
@@ -128,7 +129,7 @@ const RegisterForm = ({
           onChange={handleChange}
           value={values.password}
           isValid={isValid.password}
-          errorMessage="비밀번호는 8자 이상이어야 하며, 영문 대/소문자, 숫자, 특수문자를 포함해야 합니다."
+          errorMessage={ERROR.PASSWORD_INVAILD}
         />
         <FormField
           type="password"
@@ -138,7 +139,7 @@ const RegisterForm = ({
           onChange={handleChange}
           value={values.confirmPassword}
           isValid={isValid.confirmPassword}
-          errorMessage="비밀번호가 일치하지 않습니다."
+          errorMessage={ERROR.PASSWORD_NOT_MATCH}
         />
         <div className="sticky w-full p">
           <Button

--- a/src/pages/register/components/RegisterForm/index.tsx
+++ b/src/pages/register/components/RegisterForm/index.tsx
@@ -67,7 +67,7 @@ const RegisterForm = ({
   }, [values.email, setEmailCheckMessage, setIsEmailDuplicate]);
 
   useEffect(() => {
-    onRegisterCompleted(isCompleted && isEmailDuplicate);
+    onRegisterCompleted(isCompleted && !isEmailDuplicate);
   }, [isCompleted, isEmailDuplicate, onRegisterCompleted]);
 
   const DuplicateButton = () => (
@@ -118,7 +118,7 @@ const RegisterForm = ({
           onChange={handleChange}
           value={values.username}
           isValid={isValid.username}
-          errorMessage="이름을 3글자 이상 공백없이 입력해주세요."
+          errorMessage="이름을 3~8 글자로 공백없이 입력해주세요."
         />
         <FormField
           type="password"

--- a/src/pages/register/hooks/useEmailDuplicate.ts
+++ b/src/pages/register/hooks/useEmailDuplicate.ts
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 
 import { User } from '~/api/types/userTypes';
+import { ERROR, MESSAGE } from '~/constants/message';
 interface useEmailDuplicateParams {
   userList: User[];
 }
@@ -15,9 +16,9 @@ const useEmailDuplicate = ({ userList }: useEmailDuplicateParams) => {
 
     setIsEmailDuplicate(isDuplicate);
     if (isDuplicate) {
-      setEmailCheckMessage('이메일이 이미 사용 중입니다.');
+      setEmailCheckMessage(ERROR.DUPLICATE_EMAIL);
     } else {
-      setEmailCheckMessage('가입 가능한 이메일입니다.');
+      setEmailCheckMessage(MESSAGE.POSSIBLE_EMAIL);
     }
   };
 

--- a/src/utils/isValid.ts
+++ b/src/utils/isValid.ts
@@ -8,7 +8,7 @@ export const isValidPassword = (value: string) =>
   /[!@#$%^&*(),.?":{}|<>]/.test(value);
 
 export const isValidUsername = (value: string) =>
-  value.length >= 3 && /^[가-힣a-zA-Z0-9]+$/.test(value);
+  value.length >= 3 && value.length <= 8 && /^[가-힣a-zA-Z0-9]+$/.test(value);
 
 export const isValidPasswordMatch = ({
   value,


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- close #139 

## ✅ 작업 내용

- [x] 로그아웃 후 캐시가 제거되지않아 로그인했을 때의 데이터가 남아있는 문제
- [x] 회원가입에서 boolean값을 잘못 명시해서 생기는 문제
- [x] 닉네임 8자 제한(이후 useLayout의 타이틀이 너무 길어지는 문제)
- [x] ExtraInfo 가운데 정렬 추가

## 📝 참고 자료



## ♾️ 기타

