### PR TITLE
feat: followlist 구현

### DIFF
--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -5,7 +5,6 @@ import {
   Route,
 } from 'react-router-dom';
 
-
 import AccountPage from './pages/account';
 import AccountEditPage from './pages/accountEdit';
 import FollowPage from './pages/follow';
@@ -16,7 +15,6 @@ import MessagePage from './pages/message';
 import RegisterPage from './pages/register';
 import UpdatePasswordPage from './pages/updatePassword';
 import { AuthUserRouter, LayoutWrapper } from './routes';
-
 
 const router = createBrowserRouter(
   createRoutesFromElements(
@@ -68,7 +66,6 @@ const router = createBrowserRouter(
         <Route path="/login" element={<LoginPage />} />
         <Route path="/register" element={<RegisterPage />} />
       </Route>
-
     </Route>,
   ),
 );

--- a/src/common/hooks/queries/useAllUsers/index.ts
+++ b/src/common/hooks/queries/useAllUsers/index.ts
@@ -1,0 +1,24 @@
+import { useSuspenseQuery } from '@tanstack/react-query';
+import axios from 'axios';
+
+import { User } from '~/api/types/userTypes';
+
+const BASE_URL = import.meta.env.VITE_BASE_URL;
+const PORT = import.meta.env.VITE_PORT;
+// 추후 api 폴더 내 user.ts로 이동할 예정임
+const getUsers = async () => {
+  const { data } = await axios.get<User[]>(
+    `${BASE_URL}:${PORT}/users/get-users`,
+  );
+
+  return data;
+};
+
+export const useAllUsers = () => {
+  const { data: allUsers } = useSuspenseQuery({
+    queryKey: ['users'],
+    queryFn: getUsers,
+  });
+
+  return { allUsers };
+};

--- a/src/pages/account/components/PostsList/index.tsx
+++ b/src/pages/account/components/PostsList/index.tsx
@@ -1,58 +1,27 @@
-import Feed from '~/common/components/Feed';
 import Group from '~/common/components/Group';
-import UserInfo from '~/common/components/UserInfo';
 import { UserPost } from '~/common/hooks/queries/useUserPosts';
+import FeedItem from '~/pages/home/components/FeedItem';
 
 interface PostsListProps {
   userPosts: UserPost[];
   isMyAccount: boolean;
 }
 
-const PostsList = ({ userPosts = [], isMyAccount }: PostsListProps) => {
+const PostsList = ({ userPosts = [] }: PostsListProps) => {
   return (
     <ul className="mt flex flex-col border-t border-t-primary-lighter pt">
-      {userPosts.map(
-        ({
-          _id,
-          author,
-          channel,
-          title,
-          createdAt,
-          image,
-          likes,
-          comments,
-          content,
-        }) => {
-          const { _id: userId, image: profileImage, fullName } = author;
-          const { name: channelName } = channel;
-
-          return (
-            <Group
-              key={_id}
-              spacing={'md'}
-              direction={'columns'}
-              className="w-full  p"
-            >
-              <UserInfo
-                _id={userId}
-                profileImage={profileImage}
-                author={fullName}
-                channel={channelName}
-                createdAt={createdAt}
-                isMyAccount={isMyAccount}
-              />
-              <Feed
-                content={content}
-                initialState={false}
-                title={title}
-                image={image}
-                likes={likes}
-                comments={comments}
-              />
-            </Group>
-          );
-        },
-      )}
+      {userPosts.map(feed => {
+        return (
+          <Group
+            key={feed._id}
+            spacing={'md'}
+            direction={'columns'}
+            className="w-full p"
+          >
+            <FeedItem feed={feed} />
+          </Group>
+        );
+      })}
     </ul>
   );
 };

--- a/src/pages/account/index.tsx
+++ b/src/pages/account/index.tsx
@@ -29,7 +29,7 @@ export default function AccountPage() {
       navigate('/login');
     }
 
-    if (authUser?._id === userId) {
+    if (userId === authUser._id || !userId) {
       setIsMyAccount(true);
     } else {
       setIsMyAccount(false);

--- a/src/pages/follow/components/FollowListItem/index.tsx
+++ b/src/pages/follow/components/FollowListItem/index.tsx
@@ -1,0 +1,25 @@
+import { Link } from 'react-router-dom';
+
+import { User } from '~/api/types/userTypes';
+import Avatar from '~/common/components/Avatar';
+import Group from '~/common/components/Group';
+import Text from '~/common/components/Text';
+
+interface FollowListProps {
+  userData: User;
+}
+
+const FollowListItem = ({ userData }: FollowListProps) => {
+  const { _id, fullName, image } = userData;
+
+  return (
+    <Link to={`/account/${_id}`} className="flex flex-row">
+      <Group spacing={'md'} align={'center'}>
+        <Avatar size="full" className="h-10 w-10" src={image}></Avatar>
+        <Text>{fullName}</Text>
+      </Group>
+    </Link>
+  );
+};
+
+export default FollowListItem;

--- a/src/pages/follow/components/FollowersList/index.tsx
+++ b/src/pages/follow/components/FollowersList/index.tsx
@@ -1,0 +1,44 @@
+import { useEffect, useState } from 'react';
+
+import { Follow, User } from '~/api/types/userTypes';
+import Text from '~/common/components/Text';
+import { useAllUsers } from '~/common/hooks/queries/useAllUsers';
+
+import FollowListItem from '../FollowListItem';
+
+interface FollowListProps {
+  followers: Follow[];
+}
+
+const FollowersList = ({ followers }: FollowListProps) => {
+  const [followList, setFollowList] = useState<User[]>([]);
+  const { allUsers } = useAllUsers();
+
+  useEffect(() => {
+    const followUsers = allUsers.filter(user => {
+      return followers.some(follow => {
+        return user._id === follow.follower;
+      });
+    });
+
+    setFollowList(followUsers);
+  }, [allUsers, followers]);
+
+  return (
+    <ul className="flex flex-col gap px-small">
+      {followList.length === 0 && (
+        <Text className="mt-large text-center text-gray-400">
+          팔로워 유저가 없습니다.
+        </Text>
+      )}
+
+      {followList.map(userData => (
+        <li key={userData._id}>
+          <FollowListItem userData={userData} />
+        </li>
+      ))}
+    </ul>
+  );
+};
+
+export default FollowersList;

--- a/src/pages/follow/components/FollowingList/index.tsx
+++ b/src/pages/follow/components/FollowingList/index.tsx
@@ -1,0 +1,44 @@
+import { useEffect, useState } from 'react';
+
+import { Follow, User } from '~/api/types/userTypes';
+import Text from '~/common/components/Text';
+import { useAllUsers } from '~/common/hooks/queries/useAllUsers';
+
+import FollowListItem from '../FollowListItem';
+
+interface FollowListProps {
+  following: Follow[];
+}
+
+const FollowingList = ({ following }: FollowListProps) => {
+  const [followList, setFollowList] = useState<User[]>([]);
+  const { allUsers } = useAllUsers();
+
+  useEffect(() => {
+    const followUsers = allUsers.filter(user => {
+      return following.some(follow => {
+        return follow.user === user._id;
+      });
+    });
+
+    setFollowList(followUsers);
+  }, [allUsers, following]);
+
+  return (
+    <ul className="flex flex-col gap px-small">
+      {followList.length === 0 && (
+        <Text className="mt-large text-center text-gray-400">
+          팔로우하고 있는 유저가 없습니다.
+        </Text>
+      )}
+
+      {followList.map(userData => (
+        <li key={userData._id}>
+          <FollowListItem userData={userData} />
+        </li>
+      ))}
+    </ul>
+  );
+};
+
+export default FollowingList;

--- a/src/pages/follow/index.tsx
+++ b/src/pages/follow/index.tsx
@@ -6,6 +6,9 @@ import Group from '~/common/components/Group';
 import Tab from '~/common/components/Tab';
 import useLayout from '~/common/hooks/useLayout';
 
+import FollowersList from './components/FollowersList';
+import FollowingList from './components/FollowingList';
+
 interface FollowLocationState {
   followers: Follow[];
   following: Follow[];
@@ -24,7 +27,7 @@ const FollowPage = () => {
     initialState: { initialFollowData, initialIsFollowing },
   }: FollowLocationState = location.state;
 
-  const [, setFollowData] = useState<Follow[]>(initialFollowData);
+  const [followData, setFollowData] = useState<Follow[]>(initialFollowData);
   const [isFollowing, setIsFollowing] = useState(initialIsFollowing);
 
   useEffect(() => {
@@ -46,6 +49,11 @@ const FollowPage = () => {
         <Tab.Item title="팔로워" label="팔로워"></Tab.Item>
         <Tab.Item title="팔로잉" label="팔로잉"></Tab.Item>
       </Tab>
+      {isFollowing ? (
+        <FollowingList following={followData} />
+      ) : (
+        <FollowersList followers={followData} />
+      )}
     </Group>
   );
 };


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- close #129 

## ✅ 작업 내용

- follow 페이지에 데이터를 navigate를 활용하여 전달했습니다. (get follows 또는 get follow api 없음)
- follow 페이지 내의 user 데이터는 getusers로 가져온 데이터를 filter 처리 하여 불러왔습니다. 

## 📝 참고 자료


## ♾️ 기타

