### PR TITLE
refactor: 라우터 리다이렉트 구현

### DIFF
--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -18,7 +18,7 @@ import PostDetailPage from './pages/postDetail';
 import RegisterPage from './pages/register';
 import SearchPage from './pages/search';
 import UpdatePasswordPage from './pages/updatePassword';
-import { LayoutWrapper, PublicRouter } from './routes';
+import { LayoutWrapper, PrivateRouter, PublicRouter } from './routes';
 
 const router = createBrowserRouter(
   createRoutesFromElements(
@@ -31,44 +31,40 @@ const router = createBrowserRouter(
           </Suspense>
         }
       />
-      <Route
-        path="/account"
-        element={
-          <Suspense fallback={<div>로딩중...</div>}>
-            <AccountPage />
-          </Suspense>
-        }
-      />
-      <Route
-        path="/account/:userId"
-        element={
-          <Suspense fallback={<div>로딩중...</div>}>
-            <AccountPage />
-          </Suspense>
-        }
-      />
-      <Route
-        path="/follow"
-        element={
-          <Suspense fallback={<div>로딩중...</div>}>
-            <FollowPage />
-          </Suspense>
-        }
-      />
-      <Route path="/update-password" element={<UpdatePasswordPage />} />
-      <Route
-        path="/account-edit"
-        element={
-          <Suspense fallback={<div>로딩중...</div>}>
-            <AccountEditPage />
-          </Suspense>
-        }
-      />
-      <Route path="/message" element={<MessagePage />} />
-      <Route path="/message/:userId" element={<MessageSendPage />} />
       <Route path="/search" element={<SearchPage />} />
-      <Route path="/notification" element={<NotificationPage />} />
-      <Route path="/posts/:postId" element={<PostDetailPage />} />
+
+      <Route element={<PrivateRouter />}>
+        <Route
+          path="/account/:userId"
+          element={
+            <Suspense fallback={<div>로딩중...</div>}>
+              <AccountPage />
+            </Suspense>
+          }
+        />
+        <Route
+          path="/follow"
+          element={
+            <Suspense fallback={<div>로딩중...</div>}>
+              <FollowPage />
+            </Suspense>
+          }
+        />
+        <Route path="/update-password" element={<UpdatePasswordPage />} />
+        <Route
+          path="/account-edit"
+          element={
+            <Suspense fallback={<div>로딩중...</div>}>
+              <AccountEditPage />
+            </Suspense>
+          }
+        />
+        <Route path="/message" element={<MessagePage />} />
+        <Route path="/message/:userId" element={<MessageSendPage />} />
+        <Route path="/notification" element={<NotificationPage />} />
+        <Route path="/posts/:postId" element={<PostDetailPage />} />
+      </Route>
+
       <Route element={<PublicRouter />}>
         <Route path="/login" element={<LoginPage />} />
         <Route path="/register" element={<RegisterPage />} />

--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -41,10 +41,19 @@ const router = createBrowserRouter(
           </Suspense>
         }
       />
+      <Route
+        path="/account/:userId"
+        element={
+          <Suspense fallback={<div>로딩중...</div>}>
+            <AccountPage />
+          </Suspense>
+        }
+      />
+      <Route path="/message" element={<MessagePage />} />
 
       <Route element={<PrivateRouter />}>
         <Route
-          path="/account/:userId"
+          path="/account"
           element={
             <Suspense fallback={<div>로딩중...</div>}>
               <AccountPage />
@@ -60,7 +69,6 @@ const router = createBrowserRouter(
             </Suspense>
           }
         />
-        <Route path="/message" element={<MessagePage />} />
         <Route path="/message/:userId" element={<MessageSendPage />} />
         <Route path="/notification" element={<NotificationPage />} />
       </Route>

--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -31,7 +31,16 @@ const router = createBrowserRouter(
           </Suspense>
         }
       />
+      <Route path="/posts/:postId" element={<PostDetailPage />} />
       <Route path="/search" element={<SearchPage />} />
+      <Route
+        path="/follow"
+        element={
+          <Suspense fallback={<div>로딩중...</div>}>
+            <FollowPage />
+          </Suspense>
+        }
+      />
 
       <Route element={<PrivateRouter />}>
         <Route
@@ -39,14 +48,6 @@ const router = createBrowserRouter(
           element={
             <Suspense fallback={<div>로딩중...</div>}>
               <AccountPage />
-            </Suspense>
-          }
-        />
-        <Route
-          path="/follow"
-          element={
-            <Suspense fallback={<div>로딩중...</div>}>
-              <FollowPage />
             </Suspense>
           }
         />
@@ -62,7 +63,6 @@ const router = createBrowserRouter(
         <Route path="/message" element={<MessagePage />} />
         <Route path="/message/:userId" element={<MessageSendPage />} />
         <Route path="/notification" element={<NotificationPage />} />
-        <Route path="/posts/:postId" element={<PostDetailPage />} />
       </Route>
 
       <Route element={<PublicRouter />}>


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- close #160 

## ✅ 작업 내용

*디스코드 회의를 통해 일부 내용을 수정합니다.

- 라우터 단에서 user 정보를 통해 리다이렉트 여부를 결정합니다.
- 리다이렉트 use case는 다음과 같습니다.
1. 유저 정보와 관계 없이 이동할 수 있는 라우터
    - Home Page
    - Search Page
    - Post Detail Page
    - Follow Page
    - Account Page(다른 유저 정보)
    - Message Page
2. 유저 정보가 있을 때만 이동할 수 있는 라우터
    - Account Page(내 정보)
    - Account Edit Page
    - Message Send Page
    - Notification Page
    - Update Password Page 
3. 유저 정보가 없을 때만 이동할 수 있는 라우터
    - Login Page
    - Logout Page

제가 놓친 부분이나 잘못 생각한 부분이 있다면 언제든 말씀해주세요!
그리고 추후 추가될 라우터는 케이스 별로 라우터에 추가해주시면 되겠습니다.

## 📝 참고 자료

- 작업한 내용에 대한 부연 설명

## ♾️ 기타

- 추가로 필요한 작업 내용
