### PR TITLE
refactor: search notification

### DIFF
--- a/src/pages/notification/components/NotificationList/Alarm.tsx
+++ b/src/pages/notification/components/NotificationList/Alarm.tsx
@@ -5,6 +5,7 @@ import { Post } from '~/api/types/postTypes';
 import Group from '~/common/components/Group';
 import Text from '~/common/components/Text';
 import { cn } from '~/utils/cn';
+import { jsonToData } from '~/utils/jsonToData';
 import { elapsedTime } from '~/utils/time';
 
 interface AlarmMessages {
@@ -19,25 +20,6 @@ const Alarm = ({ alarm }: { alarm: Notification }) => {
     comment: '게시글에 댓글을 달았습니다.',
     message: '메시지를 보냈습니다.',
     like: '게시글을 좋아합니다.',
-  };
-
-  const isJson = (str: string) => {
-    try {
-      const json = JSON.parse(str);
-      return json && typeof json === 'object';
-    } catch (e) {
-      return false;
-    }
-  };
-
-  const jsonToData = (title: string) => {
-    if (isJson(title)) {
-      const { title: postTitle, content: postContent } = JSON.parse(title);
-
-      return { postTitle, postContent };
-    } else {
-      return { postTitle: title, postContent: '' };
-    }
   };
 
   useEffect(() => {

--- a/src/pages/search/components/SearchResults/PostItem.tsx
+++ b/src/pages/search/components/SearchResults/PostItem.tsx
@@ -1,4 +1,4 @@
-import { useNavigate } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 
 import { Channel, Post } from '~/api/types/postTypes';
 import { User } from '~/api/types/userTypes';
@@ -14,7 +14,6 @@ interface PostItemProps {
 }
 
 const PostItem = ({ post }: PostItemProps) => {
-  const navigate = useNavigate();
   const postObj = { title: post.title, content: '내용 없음' };
 
   if (post.title.includes('content')) {
@@ -26,38 +25,39 @@ const PostItem = ({ post }: PostItemProps) => {
 
   return (
     <>
-      <Group
-        spacing="md"
-        align="center"
-        position="apart"
-        className="my h-32 w-full cursor-pointer rounded p-small hover:bg-gray-200"
-        onClick={() => navigate(`/posts/${post._id}`)}
-      >
-        <Group direction="columns" spacing="sm" className="w-8/12">
-          <Text strong className="w-full truncate">
-            {postObj.title}
-          </Text>
-          <Text elementType="p" className="w-full truncate">
-            {postObj.content}
-          </Text>
-          <div>
-            <ExtraInfo>
-              <span className="text-base-small">
-                {(post.author as User).fullName}
-              </span>
-              <span className="text-base-small">
-                {elapsedTime(post.createdAt)}
-              </span>
-            </ExtraInfo>
-            <ExtraInfo className="pb">
-              <span className="text-base-small">
-                {(post.channel as Channel).name}
-              </span>
-            </ExtraInfo>
-          </div>
+      <Link to={`/posts/${post._id}`}>
+        <Group
+          spacing="md"
+          align="center"
+          position="apart"
+          className="my h-32 w-full cursor-pointer rounded p-small hover:bg-gray-200"
+        >
+          <Group direction="columns" spacing="sm" className="w-8/12">
+            <Text strong className="w-full truncate">
+              {postObj.title}
+            </Text>
+            <Text elementType="p" className="w-full truncate">
+              {postObj.content}
+            </Text>
+            <div>
+              <ExtraInfo>
+                <span className="text-base-small">
+                  {(post.author as User).fullName}
+                </span>
+                <span className="text-base-small">
+                  {elapsedTime(post.createdAt)}
+                </span>
+              </ExtraInfo>
+              <ExtraInfo className="pb">
+                <span className="text-base-small">
+                  {(post.channel as Channel).name}
+                </span>
+              </ExtraInfo>
+            </div>
+          </Group>
+          {post.image && <Image src={post.image} className="rounded" />}
         </Group>
-        {post.image && <Image src={post.image} />}
-      </Group>
+      </Link>
       <Divider size={8} />
     </>
   );

--- a/src/pages/search/components/SearchResults/UserItem.tsx
+++ b/src/pages/search/components/SearchResults/UserItem.tsx
@@ -1,4 +1,4 @@
-import { useNavigate } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 
 import { User } from '~/api/types/userTypes';
 import Avatar from '~/common/components/Avatar';
@@ -12,26 +12,29 @@ interface UserItemProps {
 }
 
 const UserItem = ({ user }: UserItemProps) => {
-  const navigate = useNavigate();
-
   return (
     <>
-      <Group
-        spacing="md"
-        align="center"
-        className="my h-28 w-full cursor-pointer rounded p-small hover:bg-gray-200"
-        onClick={() => navigate(`/account/${user._id}`)}
-      >
-        {user.image ? <Avatar src={user.image} /> : <Avatar />}
-        <Group direction="columns" spacing="sm" position="center">
-          <Text strong>{user.fullName}</Text>
-          <ExtraInfo>
-            <span>{`게시물 ${user.posts.length}`}</span>
-            <span>{`팔로워 ${user.followers.length}`}</span>
-            <span>{`팔로잉 ${user.following.length}`}</span>
-          </ExtraInfo>
+      <Link to={`/account/${user._id}`}>
+        <Group
+          spacing="md"
+          align="center"
+          className="my h-20 w-full cursor-pointer rounded p-small hover:bg-gray-200"
+        >
+          {user.image ? (
+            <Avatar src={user.image} size="full" className="h-14 w-14" />
+          ) : (
+            <Avatar size="full" className="h-14 w-14" />
+          )}
+          <Group direction="columns" spacing="sm" position="center">
+            <Text strong>{user.fullName}</Text>
+            <ExtraInfo>
+              <span>{`게시물 ${user.posts.length}`}</span>
+              <span>{`팔로워 ${user.followers.length}`}</span>
+              <span>{`팔로잉 ${user.following.length}`}</span>
+            </ExtraInfo>
+          </Group>
         </Group>
-      </Group>
+      </Link>
       <Divider size={8} />
     </>
   );

--- a/src/pages/search/components/SearchResults/index.tsx
+++ b/src/pages/search/components/SearchResults/index.tsx
@@ -6,6 +6,7 @@ import Group from '~/common/components/Group';
 import Loading from '~/common/components/Loading';
 import Text from '~/common/components/Text';
 import useSearchResults from '~/common/hooks/queries/useSearchResults';
+import { jsonToData } from '~/utils/jsonToData';
 
 import PostItem from './PostItem';
 import UserItem from './UserItem';
@@ -21,25 +22,6 @@ const SearchResults = ({ mode, keyword }: SearchResultsProps) => {
     mode,
     keyword,
   );
-
-  const isJson = (str: string) => {
-    try {
-      const json = JSON.parse(str);
-      return json && typeof json === 'object';
-    } catch (e) {
-      return false;
-    }
-  };
-
-  const jsonToData = (title: string) => {
-    if (isJson(title)) {
-      const { title: postTitle, content: postContent } = JSON.parse(title);
-
-      return { postTitle, postContent };
-    } else {
-      return { postTitle: title, postContent: '' };
-    }
-  };
 
   useEffect(() => {
     if (mode === 'all') {


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- close #162 

## ✅ 작업 내용
- 검색, 알림 페이지에서 `utils/jsonToData.ts`의 함수를 사용하는 것으로 변경했습니다.
- Avatar 크기를 줄였습니다.
- 페이지 이동 시 `useNavigate`를 사용하던 것에서 Link 태그 사용으로 변경했습니다.

## 📝 참고 자료
- [[React] Link 컴포넌트와 useNavigate의 차이](https://velog.io/@ahn-sujin/React-Link-%EC%BB%B4%ED%8F%AC%EB%84%8C%ED%8A%B8%EC%99%80-useNavigate%EC%9D%98-%EC%B0%A8%EC%9D%B4)

