### PR TITLE
refactor: Tab 컴포넌트 subText 추가

### DIFF
--- a/src/common/components/Tab/TabItem.tsx
+++ b/src/common/components/Tab/TabItem.tsx
@@ -5,11 +5,18 @@ import { cn } from '~/utils/cn';
 
 export interface TabItemProps extends ComponentProps<'div'> {
   title: string;
+  subText?: string | number;
   label: string;
   active?: boolean;
 }
 
-const TabItem = ({ title, active, className, ...props }: TabItemProps) => {
+const TabItem = ({
+  title,
+  subText = '',
+  active,
+  className,
+  ...props
+}: TabItemProps) => {
   return (
     <div
       {...props}
@@ -21,6 +28,9 @@ const TabItem = ({ title, active, className, ...props }: TabItemProps) => {
     >
       <Text strong={active} className={!active ? 'text-gray-400' : ''}>
         {title}
+      </Text>
+      <Text className={`ml-small text-sm ${!active && 'text-gray-400'}`}>
+        {subText}
       </Text>
     </div>
   );

--- a/src/pages/follow/index.tsx
+++ b/src/pages/follow/index.tsx
@@ -20,7 +20,7 @@ interface FollowLocationState {
 }
 
 const FollowPage = () => {
-  const { changeMeta } = useLayout();
+  const { changeMeta, changeBottomNavigator } = useLayout();
   const location = useLocation();
   const {
     followers,
@@ -29,17 +29,17 @@ const FollowPage = () => {
   }: FollowLocationState = location.state;
 
   const [followData, setFollowData] = useState<Follow[]>(initialFollowData);
-  const [isFollowing, setIsFollowing] = useState(initialIsFollowing);
 
   useEffect(() => {
+    changeBottomNavigator(true);
     changeMeta({
-      title: isFollowing ? '팔로잉' : '팔로워',
+      title: initialIsFollowing ? '팔로잉' : '팔로워',
       left: <ArrowBackButton />,
       right: <></>,
     });
 
-    isFollowing ? setFollowData(following) : setFollowData(followers);
-  }, [isFollowing, followers, following]);
+    initialIsFollowing ? setFollowData(following) : setFollowData(followers);
+  }, [followers, following]);
 
   return (
     <section className="flex flex-col overflow-hidden">
@@ -50,14 +50,13 @@ const FollowPage = () => {
         className="scroll-none mt-small flex h-full w-full flex-col overflow-y-auto pb"
       >
         <Tab
-          activeLabel={isFollowing ? '팔로잉' : '팔로워'}
-          onClick={() => setIsFollowing(prev => !prev)}
+          activeLabel={initialIsFollowing ? '팔로잉' : '팔로워'}
           className="mb"
         >
-          <Tab.Item title="팔로워" label="팔로워">
+          <Tab.Item title="팔로워" subText={followers.length} label="팔로워">
             <FollowersList followers={followData} />
           </Tab.Item>
-          <Tab.Item title="팔로잉" label="팔로잉">
+          <Tab.Item title="팔로잉" subText={following.length} label="팔로잉">
             <FollowingList following={followData} />
           </Tab.Item>
         </Tab>

--- a/src/pages/moreUsers/components/UserList/index.tsx
+++ b/src/pages/moreUsers/components/UserList/index.tsx
@@ -1,16 +1,13 @@
 import { Follow, User } from '~/api/types/userTypes';
-import useUsersList from '~/common/hooks/queries/useUsersList';
 
 import UserItem from './UserItem';
 
 interface UserList {
-  isOnline?: boolean;
+  users?: User[];
   currentUser: User | undefined;
 }
 
-const UserList = ({ isOnline = false, currentUser }: UserList) => {
-  const { users } = useUsersList(isOnline);
-
+const UserList = ({ users, currentUser }: UserList) => {
   const getFollowInfo = (id: string) => {
     const idx = (currentUser?.following as Follow[]).findIndex(
       ({ user }) => user === id,

--- a/src/pages/moreUsers/index.tsx
+++ b/src/pages/moreUsers/index.tsx
@@ -5,19 +5,24 @@ import Group from '~/common/components/Group';
 import Loading from '~/common/components/Loading';
 import Tab from '~/common/components/Tab';
 import useAuthUser from '~/common/hooks/queries/useAuthUser';
+import useUsersList from '~/common/hooks/queries/useUsersList';
 import useLayout from '~/common/hooks/useLayout';
 
 import UserList from './components/UserList';
 
 export default function MoreUsersPage() {
   const { user, isLoading } = useAuthUser();
-  const { changeMeta } = useLayout();
+  const { changeMeta, changeBottomNavigator } = useLayout();
+
+  const { users: onlineUsers } = useUsersList(true);
+  const { users: allUsers } = useUsersList(false);
 
   useEffect(() => {
+    changeBottomNavigator(true);
     changeMeta({
-      title: user?.fullName || '',
+      title: user?.fullName || '사용자',
       left: <ArrowBackButton />,
-      right: '',
+      right: <></>,
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [user]);
@@ -33,11 +38,11 @@ export default function MoreUsersPage() {
   return (
     <section className="pb-[56px]">
       <Tab>
-        <Tab.Item title="접속중" label="online">
-          <UserList currentUser={user} isOnline />
+        <Tab.Item title="접속중" subText={onlineUsers.length} label="online">
+          <UserList users={onlineUsers} currentUser={user} />
         </Tab.Item>
-        <Tab.Item title="전체 사용자" label="all">
-          <UserList currentUser={user} />
+        <Tab.Item title="전체 사용자" subText={allUsers.length} label="all">
+          <UserList users={allUsers} currentUser={user} />
         </Tab.Item>
       </Tab>
     </section>

--- a/src/pages/search/components/SearchResults/index.tsx
+++ b/src/pages/search/components/SearchResults/index.tsx
@@ -1,42 +1,22 @@
-import { useEffect, useState } from 'react';
-
 import { Post } from '~/api/types/postTypes';
 import { User } from '~/api/types/userTypes';
 import Group from '~/common/components/Group';
 import Loading from '~/common/components/Loading';
-import Text from '~/common/components/Text';
-import useSearchResults from '~/common/hooks/queries/useSearchResults';
-import { jsonToData } from '~/utils/jsonToData';
 
 import PostItem from './PostItem';
 import UserItem from './UserItem';
 
 interface SearchResultsProps {
   mode: 'all' | 'users';
-  keyword: string;
+  searchResults: Post[] | User[];
+  isLoading: boolean;
 }
 
-const SearchResults = ({ mode, keyword }: SearchResultsProps) => {
-  const [postResults, setPostResults] = useState<Post[]>([]);
-  const { data: searchResults = [], isLoading } = useSearchResults(
-    mode,
-    keyword,
-  );
-
-  useEffect(() => {
-    if (mode === 'all') {
-      const filteredSearchResults = searchResults
-        .filter(result => 'title' in result)
-        .filter(result => {
-          const { postTitle, postContent } = jsonToData((result as Post).title);
-          return postTitle.includes(keyword) || postContent.includes(keyword);
-        });
-
-      setPostResults(filteredSearchResults as Post[]);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [searchResults]);
-
+const SearchResults = ({
+  mode,
+  searchResults,
+  isLoading,
+}: SearchResultsProps) => {
   if (isLoading) {
     return (
       <Group spacing="sm" align="center" position="center" className="h-60">
@@ -47,13 +27,10 @@ const SearchResults = ({ mode, keyword }: SearchResultsProps) => {
 
   return (
     <div className="mb-xlarge">
-      <Text className="h-6 pl-small text-base-small">{`검색 결과 ${
-        mode === 'all' ? postResults.length : searchResults.length
-      }건`}</Text>
-      <div className="scroll-none h-[calc(100vh-250px)] overflow-y-auto">
+      <div className="scroll-none h-[calc(100vh-220px)] overflow-y-auto">
         {mode === 'all'
-          ? postResults &&
-            postResults.map((item: Post) => (
+          ? searchResults &&
+            (searchResults as Post[]).map((item: Post) => (
               <PostItem post={item} key={item._id} />
             ))
           : searchResults &&


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- close #171 

## ✅ 작업 내용
- Tab 컴포넌트에 아이템 수를 작성할 수 있는 `subText`를 추가했습니다.
- Tab 컴포넌트를 사용하는 Search, MoreUsers, Follow 페이지에 `subText`를 추가했습니다.

## 📝 참고 자료
<img src="https://github.com/prgrms-fe-devcourse/FEDC5_Owhat_Byunghyun/assets/42732729/c8c438e9-1eaa-4dee-873e-0061d1ee53fc" width="30%"> <img src="https://github.com/prgrms-fe-devcourse/FEDC5_Owhat_Byunghyun/assets/42732729/8d5aa293-6e70-4213-961c-a14be00ab4d4" width="30%"> <img src="https://github.com/prgrms-fe-devcourse/FEDC5_Owhat_Byunghyun/assets/42732729/3f4f52d9-f060-4b55-aa01-22634de011f4" width="30%">
