### PR TITLE
fix: comment wrap 버그 수정

### DIFF
--- a/src/pages/postDetail/components/CommentListItem/index.tsx
+++ b/src/pages/postDetail/components/CommentListItem/index.tsx
@@ -41,7 +41,7 @@ const CommentListItem = ({
           </Link>
         )}
       </div>
-      <Group direction="columns" spacing={0} className="grow">
+      <Group direction="columns" spacing={0} className="flex-1">
         <Group direction="rows" spacing="sm" align="center">
           <Text size="xsmall" strong elementType="span">
             {typeof author !== 'string' && author.fullName}


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- closed #181

## ✅ 작업 내용

- 댓글이 길어져도 wrap 되지 않도록 tailwindcss className을 추가합니다.
  - `flex-1`


## 📝 참고 자료

- 작업한 내용에 대한 부연 설명

## ♾️ 기타

- 추가로 필요한 작업 내용
