### PR TITLE
Fix: account page 수정, 다크모드 시 스타일 수정

### DIFF
--- a/src/common/components/AcordionButton/index.tsx
+++ b/src/common/components/AcordionButton/index.tsx
@@ -36,7 +36,7 @@ const AcordionButton = () => {
           <ThemeButton className="p-1" />
         </li>
         <li>
-          <div className="rounded-full dark:bg-transparent">
+          <div className="rounded-full shadow-md dark:bg-black dark:fill-primary dark:shadow-gray-800">
             <Suspense>
               <PostCreateButton />
             </Suspense>

--- a/src/common/components/ThemeButton/index.tsx
+++ b/src/common/components/ThemeButton/index.tsx
@@ -43,7 +43,7 @@ const ThemeButton = ({ className }: ThemeButton) => {
   return (
     <Button
       className={cn(
-        'z-10 rounded-full shadow-md dark:bg-transparent',
+        'z-10 rounded-full shadow-md dark:bg-black dark:fill-primary dark:shadow-gray-800',
         className,
       )}
       styleType="secondary"

--- a/src/common/components/Toast/ToastItem.tsx
+++ b/src/common/components/Toast/ToastItem.tsx
@@ -22,7 +22,7 @@ const ToastItem = ({ message, duration, onDone }: ToastItemProps) => {
     <div
       className={cn(
         'duration-400 relative mx mb-2 flex h-16 w-layout max-w-[296px] items-center ',
-        'animate-move rounded border border-solid border-gray-300 bg-white p-4 opacity-100 shadow-md transition-opacity ease-out',
+        'animate-move overflow-hidden rounded bg-white p-4 opacity-100 shadow-md transition-opacity ease-out',
         !show && 'opacity-0',
       )}
     >
@@ -33,7 +33,7 @@ const ToastItem = ({ message, duration, onDone }: ToastItemProps) => {
         )}
         style={{ animationDuration: `${duration}ms` }}
       />
-      <Text>{message}</Text>
+      <Text className="dark:text-black">{message}</Text>
     </div>
   );
 };

--- a/src/common/hooks/mutations/useUploadImage/index.tsx
+++ b/src/common/hooks/mutations/useUploadImage/index.tsx
@@ -10,6 +10,7 @@ export const useUploadImage = () => {
     mutationFn: postUploadImage,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [QUERY_KEY.USER] });
+      queryClient.invalidateQueries({ queryKey: [QUERY_KEY.POST_LIST] });
     },
     onError: error => {
       if (error instanceof Error) console.warn(error.message);

--- a/src/common/hooks/queries/useAllUsers/index.ts
+++ b/src/common/hooks/queries/useAllUsers/index.ts
@@ -4,10 +4,10 @@ import { getAllUsers } from '~/api/user';
 import { QUERY_KEY } from '~/constants/queryKey';
 
 export const useAllUsers = () => {
-  const { data: allUsers } = useQuery({
+  const { data: allUsers, isLoading } = useQuery({
     queryKey: [QUERY_KEY.USER_LIST],
     queryFn: getAllUsers,
   });
 
-  return { allUsers };
+  return { allUsers, isLoading };
 };

--- a/src/pages/accountEdit/components/EditAccountImages/index.tsx
+++ b/src/pages/accountEdit/components/EditAccountImages/index.tsx
@@ -93,9 +93,11 @@ const EditAccountImages = ({
           }}
         >
           {src => (
-            <div className="relative">
-              <Avatar src={src || image} size="small" />
-              <div className="group absolute top-0 box-border h-full w-full -translate-y-[0.2rem] cursor-pointer rounded-full bg-black opacity-20 ring-1 ring-black ring-offset-2 transition hover:opacity-50 hover:duration-500 hover:ease-in-out">
+            <div className="relative h-[80px] w-[80px]">
+              <div className="absolute left-0 top-0">
+                <Avatar src={src || image} size="small" />
+              </div>
+              <div className="group absolute left-0 top-0 box-border h-full w-full  cursor-pointer rounded-full bg-black opacity-20 ring-1 ring-black ring-offset-2 transition hover:opacity-50 hover:duration-500 hover:ease-in-out">
                 <Icon
                   id="add-circle"
                   className="absolute left-1/2 top-1/2 z-10 -translate-x-1/2 -translate-y-1/2 fill-white drop-shadow-md"

--- a/src/pages/follow/components/FollowersList/index.tsx
+++ b/src/pages/follow/components/FollowersList/index.tsx
@@ -11,17 +11,19 @@ interface FollowListProps {
 }
 
 const FollowersList = ({ followers }: FollowListProps) => {
-  const { allUsers = [] } = useAllUsers();
+  const { allUsers = [], isLoading } = useAllUsers();
   const [followList, setFollowList] = useState<User[]>([]);
 
   useEffect(() => {
-    const followUsers = allUsers.filter(user => {
-      return followers.some(follow => {
-        return user._id === follow.follower;
+    if (!isLoading) {
+      const followUsers = allUsers.filter(user => {
+        return followers.some(follow => {
+          return user._id === follow.follower;
+        });
       });
-    });
 
-    setFollowList(followUsers);
+      setFollowList(followUsers);
+    }
   }, [allUsers, followers]);
 
   return (

--- a/src/pages/follow/components/FollowingList/index.tsx
+++ b/src/pages/follow/components/FollowingList/index.tsx
@@ -11,17 +11,19 @@ interface FollowListProps {
 }
 
 const FollowingList = ({ following }: FollowListProps) => {
-  const { allUsers = [] } = useAllUsers();
+  const { allUsers = [], isLoading } = useAllUsers();
   const [followList, setFollowList] = useState<User[]>([]);
 
   useEffect(() => {
-    const followUsers = allUsers.filter(user => {
-      return following.some(follow => {
-        return follow.user === user._id;
+    if (!isLoading) {
+      const followUsers = allUsers.filter(user => {
+        return following.some(follow => {
+          return follow.user === user._id;
+        });
       });
-    });
 
-    setFollowList(followUsers);
+      setFollowList(followUsers);
+    }
   }, [allUsers, following]);
 
   return (

--- a/src/pages/search/components/SearchBar/index.tsx
+++ b/src/pages/search/components/SearchBar/index.tsx
@@ -38,7 +38,7 @@ const SearchBar = ({ onSubmit, onChange }: SearchBarProps) => {
           name="search"
           onChange={handleInputChange}
           value={inputValue}
-          className="grow"
+          className="grow dark:bg-transparent"
         />
         <Icon
           id="cancel"

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -23,7 +23,7 @@
     height: 100dvh;
     transition: color 0.3s;
     transition: background-color 0.3s;
-    @apply text-black dark:bg-[#141414] dark:text-white dark:[&_input]:text-black dark:[&_svg]:fill-white;
+    @apply text-black dark:bg-[#141414] dark:text-white dark:[&_input]:text-black dark:[&_svg]:fill-white dark:[&_textarea]:bg-transparent;
   }
 
   main > section {


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- close #184 

## ✅ 작업 내용

- 계정 페이지 아바타의 크기가 맞지 않는 부분을 수정했습니다.
- 계정 변경 로직에 post를 invalidatequeries에 추가하여 계정을 수정한 이후 아바타 사진이 바로 리패치 되도록 하였습니다.
- 다크모드 시에 라이트 모드 일때와 동일한 스타일을 수정하였습니다.

## 📝 참고 자료

- 작업한 내용에 대한 부연 설명

## ♾️ 기타

- 추가로 필요한 작업 내용
