### PR TITLE
Fix/#193 comment post detail

### DIFF
--- a/src/common/components/UserInfo/index.tsx
+++ b/src/common/components/UserInfo/index.tsx
@@ -1,7 +1,7 @@
 import { ComponentProps } from 'react';
 import { Link } from 'react-router-dom';
 
-import { PostResponse } from '~/api/types/postTypes';
+import { Post } from '~/api/types/postTypes';
 import { User } from '~/api/types/userTypes';
 import { cn } from '~/utils/cn';
 import { elapsedTime } from '~/utils/time';
@@ -14,7 +14,7 @@ import Text from '../Text';
 type textSize = 'xsmall' | 'small' | 'base' | 'large' | 'xlarge' | '2xlarge';
 
 interface UserInfoProps extends ComponentProps<'div'> {
-  post: PostResponse;
+  post: Post;
   authUser: User;
   authorTextSize?: textSize;
   extraInfoTextSize?: textSize;
@@ -32,6 +32,10 @@ const UserInfo = ({
 }: UserInfoProps) => {
   const { author, channel, createdAt } = post;
   const { _id: authUserId } = authUser;
+
+  if (typeof author === 'string' || typeof channel === 'string') {
+    return;
+  }
 
   return (
     <Group spacing={betweenGap} align="center">

--- a/src/pages/postDetail/components/CommentListItem/index.tsx
+++ b/src/pages/postDetail/components/CommentListItem/index.tsx
@@ -11,6 +11,7 @@ import MoreButton from '../MoreButton';
 
 interface CommentListItemProps {
   id: string;
+  authUserId: string;
   author: User | string;
   createdAt: string;
   comment: string;
@@ -19,6 +20,7 @@ interface CommentListItemProps {
 
 const CommentListItem = ({
   id,
+  authUserId,
   author,
   createdAt,
   comment,
@@ -34,13 +36,14 @@ const CommentListItem = ({
 
   return (
     <Group direction="rows" spacing={14} align="center" className="w-full">
-      <div className="w-8">
-        {typeof author !== 'string' && (
-          <Link to={`/account/${id}`} className="flex items-center">
-            <Avatar size="auto" src={author.image} />
-          </Link>
-        )}
-      </div>
+      {typeof author !== 'string' && (
+        <Link
+          to={authUserId === author._id ? `/account` : `/account/${author._id}`}
+          className="flex items-center"
+        >
+          <Avatar size="auto" src={author.image} className="h-9 w-9" />
+        </Link>
+      )}
       <Group direction="columns" spacing={0} className="flex-1">
         <Group direction="rows" spacing="sm" align="center">
           <Text size="xsmall" strong elementType="span">

--- a/src/pages/postDetail/components/PostDetailComponent/index.tsx
+++ b/src/pages/postDetail/components/PostDetailComponent/index.tsx
@@ -4,12 +4,12 @@ import Divider from '~/common/components/Divider';
 import Feed from '~/common/components/Feed';
 import Group from '~/common/components/Group';
 import Text from '~/common/components/Text';
+import UserInfo from '~/common/components/UserInfo';
 import useLikeFromPost from '~/common/hooks/mutations/useLikeFromPost';
 
 import CommentInput from '../CommentInput';
 import CommentListItem from '../CommentListItem';
 import MoreButton from '../MoreButton';
-import PostDetailUserInfo from '../PostDetailUserInfo';
 
 interface PostDetailComponent {
   postDetailData: Post;
@@ -51,13 +51,7 @@ const PostDetailComponent = ({
     <>
       <Group direction="columns" spacing="sm" grow>
         <div className="flex justify-between">
-          <PostDetailUserInfo
-            _id={postDetailData.author._id}
-            fullName={postDetailData.author.fullName}
-            profileImage={postDetailData.author?.image}
-            channelName={postDetailData.channel.name}
-            createdAt={postDetailData.createdAt}
-          />
+          <UserInfo post={postDetailData} authUser={user}></UserInfo>
           {postDetailData.author._id === user?._id && (
             <div className="self-start">
               <MoreButton
@@ -90,6 +84,7 @@ const PostDetailComponent = ({
             <CommentListItem
               key={comment._id}
               id={comment._id}
+              authUserId={user?._id}
               author={comment.author}
               createdAt={comment.createdAt}
               comment={comment.comment}


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- close #193 

## ✅ 작업 내용

1. 댓글 프로필 누르면 undefined가 뜨는 버그 해결
![스크린샷 2024-01-18 오후 2 11 01](https://github.com/prgrms-fe-devcourse/FEDC5_Owhat_Byunghyun/assets/114740795/e809f788-9d9f-44ca-b418-7e286856bba7)
![스크린샷 2024-01-18 오후 2 11 10](https://github.com/prgrms-fe-devcourse/FEDC5_Owhat_Byunghyun/assets/114740795/080456dd-867e-4d5f-bbf7-ccc6f5575349)

2. 댓글 프로필 늘어나있는 현상 문제 해결
![스크린샷 2024-01-18 오후 2 25 19](https://github.com/prgrms-fe-devcourse/FEDC5_Owhat_Byunghyun/assets/114740795/aa129607-dd6e-4932-bc2c-be16016043a6)

3. 댓글 프로필 link에 분기처리 없는 부분 발견하여 수정
![스크린샷 2024-01-18 오후 2 26 26](https://github.com/prgrms-fe-devcourse/FEDC5_Owhat_Byunghyun/assets/114740795/a5e4f29e-afb2-465b-bbe0-e3a621f82e37)
![스크린샷 2024-01-18 오후 2 29 45](https://github.com/prgrms-fe-devcourse/FEDC5_Owhat_Byunghyun/assets/114740795/169fd2f1-2b51-4421-a012-3ba315a03c6a)

4.  포스트 디테일 userinfo도 분기처리가 없어서 공통 UserInfo로 변경 (댓글과 달리 공통과 스타일이 같아서 이걸로 대체해도 스타일 문제없음)
![스크린샷 2024-01-18 오후 2 22 17](https://github.com/prgrms-fe-devcourse/FEDC5_Owhat_Byunghyun/assets/114740795/702221e4-98f5-493e-a72f-a10f954efc1f)
![스크린샷 2024-01-18 오후 2 51 08](https://github.com/prgrms-fe-devcourse/FEDC5_Owhat_Byunghyun/assets/114740795/2d9e444b-7aa5-4667-be10-f310f9cb1fa8)


## 📝 참고 자료

- 

## ♾️ 기타

- 
