### PR TITLE
refactor: 검색바, 메시지 송수신 다크모드 스타일링

### DIFF
--- a/src/pages/messageSend/components/MessageSendList/index.tsx
+++ b/src/pages/messageSend/components/MessageSendList/index.tsx
@@ -47,9 +47,7 @@ const MessageSendList = ({
           <span
             className={cn(
               'inline-block w-auto rounded px-3 py-2',
-              message.sender._id === user?._id
-                ? 'bg-primary-lighter'
-                : 'bg-gray-300',
+              message.sender._id === user?._id ? 'bg-gray-500' : 'bg-primary',
             )}
           >
             {message.message}

--- a/src/pages/search/components/SearchBar/index.tsx
+++ b/src/pages/search/components/SearchBar/index.tsx
@@ -38,7 +38,7 @@ const SearchBar = ({ onSubmit, onChange }: SearchBarProps) => {
           name="search"
           onChange={handleInputChange}
           value={inputValue}
-          className="w-full dark:bg-transparent"
+          className="w-full dark:bg-transparent dark:text-white"
         />
         <Icon
           id="cancel"


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- close #195 

## ✅ 작업 내용

- 검색 바, 메시지 송수신 페이지가 다크모드일 때 시각적으로 잘 보이지 않는 문제 해결
- 모바일 타이틀 문제는 웹이나 다른 환경에서는 잘 작동함 추후 다시 해결해야하는 문제 - 인스타 외부링크로 가는 특정한 상황에만 발생함

## 📝 참고 자료


## ♾️ 기타


